### PR TITLE
Fix slack menu limit

### DIFF
--- a/nautobot_chatops/dispatchers/adaptive_cards.py
+++ b/nautobot_chatops/dispatchers/adaptive_cards.py
@@ -144,7 +144,7 @@ class AdaptiveCardsDispatcher(Dispatcher):
         blocks = [self.markdown_block(help_text), self.actions_block("TODO", [textentry, buttons])]
         return self.send_blocks(blocks, ephemeral=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False):
+    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False, tracker=0):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
@@ -153,6 +153,7 @@ class AdaptiveCardsDispatcher(Dispatcher):
           choices (list): List of (display, value) tuples
           default (tuple): Default (display, valud) to pre-select.
           confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
+          tracker (int): Only used for Slack, as it has a hard display limit of 100
         """
         menu = self.select_element("param_0", choices, default=default, confirm=confirm)
         buttons = {

--- a/nautobot_chatops/dispatchers/adaptive_cards.py
+++ b/nautobot_chatops/dispatchers/adaptive_cards.py
@@ -147,13 +147,14 @@ class AdaptiveCardsDispatcher(Dispatcher):
         blocks = [self.markdown_block(help_text), self.actions_block("TODO", [textentry, buttons])]
         return self.send_blocks(blocks, ephemeral=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, tracker=0, confirm_choices={}):
+    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices={}):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
           choices (list): List of (display, value) tuples
+          offset (int): Used for apps that have a menu selection display limit.
           confirm_choices (dict):  List of dictionaries containing the dialog parameters.
             - default (tuple): Default (display, value) to pre-select.
             - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)

--- a/nautobot_chatops/dispatchers/adaptive_cards.py
+++ b/nautobot_chatops/dispatchers/adaptive_cards.py
@@ -90,7 +90,10 @@ class AdaptiveCardsDispatcher(Dispatcher):
         for i, dialog in enumerate(dialog_list):
             if dialog["type"] == "select":
                 menu = self.select_element(
-                    f"param_{i}", dialog["choices"], dialog.get("default", (None, None)), dialog.get("confirm", False)
+                    f"param_{i}",
+                    dialog["choices"],
+                    default=dialog.get("default", (None, None)),
+                    confirm=dialog.get("confirm", False),
                 )
                 blocks.append(self.text_element(dialog["label"]))
                 blocks.append(menu)
@@ -144,18 +147,23 @@ class AdaptiveCardsDispatcher(Dispatcher):
         blocks = [self.markdown_block(help_text), self.actions_block("TODO", [textentry, buttons])]
         return self.send_blocks(blocks, ephemeral=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False, tracker=0):
+    def prompt_from_menu(self, action_id, help_text, choices, tracker=0, confirm_choices={}):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
           choices (list): List of (display, value) tuples
-          default (tuple): Default (display, valud) to pre-select.
-          confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
-          tracker (int): Only used for Slack, as it has a hard display limit of 100
+          confirm_choices (dict):  List of dictionaries containing the dialog parameters.
+            - default (tuple): Default (display, value) to pre-select.
+            - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
         """
-        menu = self.select_element("param_0", choices, default=default, confirm=confirm)
+        menu = self.select_element(
+            "param_0",
+            choices,
+            default=confirm_choices.get("default", (None, None)),
+            confirm=confirm_choices.get("confirm", False),
+        )
         buttons = {
             "type": "ActionSet",
             "id": "action",

--- a/nautobot_chatops/dispatchers/adaptive_cards.py
+++ b/nautobot_chatops/dispatchers/adaptive_cards.py
@@ -147,25 +147,20 @@ class AdaptiveCardsDispatcher(Dispatcher):
         blocks = [self.markdown_block(help_text), self.actions_block("TODO", [textentry, buttons])]
         return self.send_blocks(blocks, ephemeral=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices=None):
+    def prompt_from_menu(
+        self, action_id, help_text, choices, default=(None, None), confirm=False, offset=0
+    ):  # pylint: disable=too-many-arguments
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
-          choices (list): List of (display, value) tuples
+          choices (list): List of (display, value) tuples.
+          default (tuple): Default (display, value) to pre-select.
+          confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this).
           offset (int): Used for apps that have a menu selection display limit.
-          confirm_choices (dict):  List of dictionaries containing the dialog parameters.
-            - default (tuple): Default (display, value) to pre-select.
-            - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
         """
-        confirm_choices = confirm_choices or {}
-        menu = self.select_element(
-            "param_0",
-            choices,
-            default=confirm_choices.get("default", (None, None)),
-            confirm=confirm_choices.get("confirm", False),
-        )
+        menu = self.select_element("param_0", choices, default=default, confirm=confirm)
         buttons = {
             "type": "ActionSet",
             "id": "action",

--- a/nautobot_chatops/dispatchers/adaptive_cards.py
+++ b/nautobot_chatops/dispatchers/adaptive_cards.py
@@ -147,7 +147,7 @@ class AdaptiveCardsDispatcher(Dispatcher):
         blocks = [self.markdown_block(help_text), self.actions_block("TODO", [textentry, buttons])]
         return self.send_blocks(blocks, ephemeral=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices={}):
+    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices=None):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
@@ -159,6 +159,7 @@ class AdaptiveCardsDispatcher(Dispatcher):
             - default (tuple): Default (display, value) to pre-select.
             - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
         """
+        confirm_choices = confirm_choices or {}
         menu = self.select_element(
             "param_0",
             choices,

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -194,14 +194,14 @@ class Dispatcher:
         """
         raise NotImplementedError
 
-    def prompt_from_menu(self, action_id, help_text, choices, tracker=0, confirm_choices={}):
+    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices={}):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
           choices (list): List of (display, value) tuples
-          tracker (int): Used for apps that have a menu selection display limit.
+          offset (int): Used for apps that have a menu selection display limit.
           confirm_choices (dict):  List of dictionaries containing the dialog parameters.
             - default (tuple): Default (display, value) to pre-select.
             - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -194,7 +194,7 @@ class Dispatcher:
         """
         raise NotImplementedError
 
-    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False. tracker=0):
+    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False, tracker=0):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -194,7 +194,7 @@ class Dispatcher:
         """
         raise NotImplementedError
 
-    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices={}):
+    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices=None):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -194,17 +194,18 @@ class Dispatcher:
         """
         raise NotImplementedError
 
-    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices=None):
+    def prompt_from_menu(
+        self, action_id, help_text, choices, default=(None, None), confirm=False, offset=0
+    ):  # pylint: disable=too-many-arguments
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
-          choices (list): List of (display, value) tuples
+          choices (list): List of (display, value) tuples.
+          default (tuple): Default (display, value) to pre-select.
+          confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this).
           offset (int): Used for apps that have a menu selection display limit.
-          confirm_choices (dict):  List of dictionaries containing the dialog parameters.
-            - default (tuple): Default (display, value) to pre-select.
-            - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
         """
         raise NotImplementedError
 

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -194,7 +194,7 @@ class Dispatcher:
         """
         raise NotImplementedError
 
-    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False):
+    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False. tracker=0):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
@@ -203,6 +203,7 @@ class Dispatcher:
           choices (list): List of (display, value) tuples
           default (tuple): Default (display, valud) to pre-select.
           confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
+          tracker (int): Only used for Slack, as it has a hard display limit of 100
         """
         raise NotImplementedError
 

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -194,16 +194,17 @@ class Dispatcher:
         """
         raise NotImplementedError
 
-    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False, tracker=0):
+    def prompt_from_menu(self, action_id, help_text, choices, tracker=0, confirm_choices={}):
         """Prompt the user to make a selection from a menu of choices.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
           choices (list): List of (display, value) tuples
-          default (tuple): Default (display, valud) to pre-select.
-          confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
-          tracker (int): Only used for Slack, as it has a hard display limit of 100
+          tracker (int): Used for apps that have a menu selection display limit.
+          confirm_choices (dict):  List of dictionaries containing the dialog parameters.
+            - default (tuple): Default (display, value) to pre-select.
+            - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
         """
         raise NotImplementedError
 

--- a/nautobot_chatops/dispatchers/mattermost.py
+++ b/nautobot_chatops/dispatchers/mattermost.py
@@ -480,7 +480,7 @@ class MattermostDispatcher(Dispatcher):  # pylint: disable=too-many-public-metho
         # In Mattermost, a textentry element can ONLY be sent in a modal Interactive dialog
         return self.send_blocks(blocks, callback_id=action_id, ephemeral=False, modal=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices={}):
+    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices=None):
         """Prompt the user for a selection from a menu.
 
         Args:
@@ -494,6 +494,7 @@ class MattermostDispatcher(Dispatcher):  # pylint: disable=too-many-public-metho
         """
         # Default and Confirm options can only be done in Interactive Dialog.  Since the prompt_from_menu is
         # using Ephemeral we will build the basic select.  multi_input_dialog will use the Interactive Dialog.
+        confirm_choices = confirm_choices or {}
         logger.info(
             "Ignoring: prompt_from_menu cannot use provided default: %s or confirm: %s",
             confirm_choices.get("default", (None, None)),

--- a/nautobot_chatops/dispatchers/mattermost.py
+++ b/nautobot_chatops/dispatchers/mattermost.py
@@ -480,20 +480,24 @@ class MattermostDispatcher(Dispatcher):  # pylint: disable=too-many-public-metho
         # In Mattermost, a textentry element can ONLY be sent in a modal Interactive dialog
         return self.send_blocks(blocks, callback_id=action_id, ephemeral=False, modal=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False, tracker=0):
+    def prompt_from_menu(self, action_id, help_text, choices, tracker=0, confirm_choices={}):
         """Prompt the user for a selection from a menu.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
           choices (list): List of (display, value) tuples
-          default (tuple): Default (display, valud) to pre-select.
-          confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
-          tracker (int): Only used for Slack, as it has a hard display limit of 100
+          confirm_choices (dict):  List of dictionaries containing the dialog parameters.
+            - default (tuple): Default (display, value) to pre-select.
+            - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
         """
         # Default and Confirm options can only be done in Interactive Dialog.  Since the prompt_from_menu is
         # using Ephemeral we will build the basic select.  multi_input_dialog will use the Interactive Dialog.
-        logger.info("Ignoring: prompt_from_menu cannot use provided default: %s or confirm: %s", default, confirm)
+        logger.info(
+            "Ignoring: prompt_from_menu cannot use provided default: %s or confirm: %s",
+            confirm_choices.get("default", (None, None)),
+            confirm_choices.get("confirm", False),
+        )
         menu = self.select_element(action_id, choices)
         cancel_button = {
             "id": "Cancel",

--- a/nautobot_chatops/dispatchers/mattermost.py
+++ b/nautobot_chatops/dispatchers/mattermost.py
@@ -480,13 +480,14 @@ class MattermostDispatcher(Dispatcher):  # pylint: disable=too-many-public-metho
         # In Mattermost, a textentry element can ONLY be sent in a modal Interactive dialog
         return self.send_blocks(blocks, callback_id=action_id, ephemeral=False, modal=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, tracker=0, confirm_choices={}):
+    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices={}):
         """Prompt the user for a selection from a menu.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
           choices (list): List of (display, value) tuples
+          offset (int): Used for apps that have a menu selection display limit.
           confirm_choices (dict):  List of dictionaries containing the dialog parameters.
             - default (tuple): Default (display, value) to pre-select.
             - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)

--- a/nautobot_chatops/dispatchers/mattermost.py
+++ b/nautobot_chatops/dispatchers/mattermost.py
@@ -480,26 +480,22 @@ class MattermostDispatcher(Dispatcher):  # pylint: disable=too-many-public-metho
         # In Mattermost, a textentry element can ONLY be sent in a modal Interactive dialog
         return self.send_blocks(blocks, callback_id=action_id, ephemeral=False, modal=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices=None):
+    def prompt_from_menu(
+        self, action_id, help_text, choices, default=(None, None), confirm=False, offset=0
+    ):  # pylint: disable=too-many-arguments
         """Prompt the user for a selection from a menu.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
-          choices (list): List of (display, value) tuples
+          choices (list): List of (display, value) tuples.
+          default (tuple): Default (display, value) to pre-select.
+          confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this).
           offset (int): Used for apps that have a menu selection display limit.
-          confirm_choices (dict):  List of dictionaries containing the dialog parameters.
-            - default (tuple): Default (display, value) to pre-select.
-            - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
         """
         # Default and Confirm options can only be done in Interactive Dialog.  Since the prompt_from_menu is
         # using Ephemeral we will build the basic select.  multi_input_dialog will use the Interactive Dialog.
-        confirm_choices = confirm_choices or {}
-        logger.info(
-            "Ignoring: prompt_from_menu cannot use provided default: %s or confirm: %s",
-            confirm_choices.get("default", (None, None)),
-            confirm_choices.get("confirm", False),
-        )
+        logger.info("Ignoring: prompt_from_menu cannot use provided default: %s or confirm: %s", default, confirm)
         menu = self.select_element(action_id, choices)
         cancel_button = {
             "id": "Cancel",

--- a/nautobot_chatops/dispatchers/mattermost.py
+++ b/nautobot_chatops/dispatchers/mattermost.py
@@ -480,7 +480,7 @@ class MattermostDispatcher(Dispatcher):  # pylint: disable=too-many-public-metho
         # In Mattermost, a textentry element can ONLY be sent in a modal Interactive dialog
         return self.send_blocks(blocks, callback_id=action_id, ephemeral=False, modal=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False):
+    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False, tracker=0):
         """Prompt the user for a selection from a menu.
 
         Args:
@@ -489,6 +489,7 @@ class MattermostDispatcher(Dispatcher):  # pylint: disable=too-many-public-metho
           choices (list): List of (display, value) tuples
           default (tuple): Default (display, valud) to pre-select.
           confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
+          tracker (int): Only used for Slack, as it has a hard display limit of 100
         """
         # Default and Confirm options can only be done in Interactive Dialog.  Since the prompt_from_menu is
         # using Ephemeral we will build the basic select.  multi_input_dialog will use the Interactive Dialog.

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import time
 
 from django.conf import settings
@@ -37,7 +38,7 @@ class SlackDispatcher(Dispatcher):
         """Init a SlackDispatcher."""
         super().__init__(*args, **kwargs)
         self.slack_client = WebClient(token=settings.PLUGINS_CONFIG["nautobot_chatops"]["slack_api_token"])
-        self.slack_menu_limit = 100
+        self.slack_menu_limit = int(os.getenv("SLACK_MENU_LIMIT", 100))
 
     @classmethod
     @BACKEND_ACTION_LOOKUP.time()

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -36,6 +36,7 @@ class SlackDispatcher(Dispatcher):
         """Init a SlackDispatcher."""
         super().__init__(*args, **kwargs)
         self.slack_client = WebClient(token=settings.PLUGINS_CONFIG["nautobot_chatops"]["slack_api_token"])
+        self.slack_menu_limit = 100
 
     @classmethod
     @BACKEND_ACTION_LOOKUP.time()
@@ -272,20 +273,32 @@ class SlackDispatcher(Dispatcher):
         # In Slack, a textentry element can ONLY be sent in a modal dialog
         return self.send_blocks(blocks, callback_id=action_id, ephemeral=True, modal=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False):
+    def prompt_from_menu(self, action_id, help_text, choices, default=(None, None), confirm=False, tracker=0):
         """Prompt the user for a selection from a menu.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
           choices (list): List of (display, value) tuples
-          default (tuple): Default (display, valud) to pre-select.
+          default (tuple): Default (display, value) to pre-select.
           confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
+          tracker (int): If set, starts displaying choices at index location from all choices,
+                         as Slack only displays 100 options at a time
         """
-        # TODO: Slack limits an option list to no more than 100 items. How can we work around this?
-        if len(choices) > 100:
-            self.send_warning("More than 100 options are available. Slack limits us to the first 100.")
-            choices = choices[:100]
+        choice_length = len(choices)
+        if choice_length > self.slack_menu_limit:
+            self.send_warning(
+                f"More than {self.slack_menu_limit} options are available. Slack limits us to only displaying {self.slack_menu_limit} options at a time."
+            )
+            new_tracker = tracker + self.slack_menu_limit - 1
+            if tracker == 0:
+                choices = choices[: self.slack_menu_limit - 1]  # 1 is to leave space for 'next' insert
+            else:
+                choices = choices[tracker:new_tracker]
+            if choice_length > new_tracker:
+                # Only insert a 'next' tracker if we still have more choices left to see
+                choices.append(("Next...", f"menu_track...{new_tracker}"))
+
         menu = self.select_element(action_id, choices, default=default, confirm=confirm)
         cancel_button = {
             "type": "button",

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -304,28 +304,22 @@ class SlackDispatcher(Dispatcher):
                 choices.append(("Next...", f"menu_offset-{new_offset}"))
         return choices
 
-    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices=None):
+    def prompt_from_menu(
+        self, action_id, help_text, choices, default=(None, None), confirm=False, offset=0
+    ):  # pylint: disable=too-many-arguments
         """Prompt the user for a selection from a menu.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
-          choices (list): List of (display, value) tuples
+          choices (list): List of (display, value) tuples.
+          default (tuple): Default (display, value) to pre-select.
+          confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this).
           offset (int): If set, starts displaying choices at index location from all choices,
-                         as Slack only displays 100 options at a time
-          confirm_choices (dict):  List of dictionaries containing the dialog parameters.
-            - default (tuple): Default (display, value) to pre-select.
-            - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
+                         as Slack only displays 100 options at a time.
         """
-        confirm_choices = confirm_choices or {}
         choices = self.get_prompt_from_menu_choices(choices, offset=offset)
-
-        menu = self.select_element(
-            action_id,
-            choices,
-            default=confirm_choices.get("default", (None, None)),
-            confirm=confirm_choices.get("confirm", False),
-        )
+        menu = self.select_element(action_id, choices, default=default, confirm=confirm)
         cancel_button = {
             "type": "button",
             "text": self.text_element("Cancel"),

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -297,7 +297,7 @@ class SlackDispatcher(Dispatcher):
                 choices = choices[tracker:new_tracker]
             if choice_length > new_tracker:
                 # Only insert a 'next' tracker if we still have more choices left to see
-                choices.append(("Next...", f"menu_track...{new_tracker}"))
+                choices.append(("Next...", f"menu_track-{new_tracker}"))
 
         menu = self.select_element(action_id, choices, default=default, confirm=confirm)
         cancel_button = {

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -273,14 +273,14 @@ class SlackDispatcher(Dispatcher):
         # In Slack, a textentry element can ONLY be sent in a modal dialog
         return self.send_blocks(blocks, callback_id=action_id, ephemeral=True, modal=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, tracker=0, confirm_choices={}):
+    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices={}):
         """Prompt the user for a selection from a menu.
 
         Args:
           action_id (str): Identifier string to attach to the "submit" action.
           help_text (str): Markdown string to display as help text.
           choices (list): List of (display, value) tuples
-          tracker (int): If set, starts displaying choices at index location from all choices,
+          offset (int): If set, starts displaying choices at index location from all choices,
                          as Slack only displays 100 options at a time
           confirm_choices (dict):  List of dictionaries containing the dialog parameters.
             - default (tuple): Default (display, value) to pre-select.
@@ -291,14 +291,14 @@ class SlackDispatcher(Dispatcher):
             self.send_warning(
                 f"More than {self.slack_menu_limit} options are available. Slack limits us to only displaying {self.slack_menu_limit} options at a time."
             )
-            new_tracker = tracker + self.slack_menu_limit - 1
-            if tracker == 0:
+            new_offset = offset + self.slack_menu_limit - 1
+            if offset == 0:
                 choices = choices[: self.slack_menu_limit - 1]  # 1 is to leave space for 'next' insert
             else:
-                choices = choices[tracker:new_tracker]
-            if choice_length > new_tracker:
-                # Only insert a 'next' tracker if we still have more choices left to see
-                choices.append(("Next...", f"menu_track-{new_tracker}"))
+                choices = choices[offset:new_offset]
+            if choice_length > new_offset:
+                # Only insert a 'next' offset if we still have more choices left to see
+                choices.append(("Next...", f"menu_offset-{new_offset}"))
 
         menu = self.select_element(
             action_id,

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -24,6 +24,7 @@ BACKEND_ACTION_SNIPPET = backend_action_sum.labels("slack", "send_snippet")
 class SlackDispatcher(Dispatcher):
     """Dispatch messages and cards to Slack."""
 
+    # pylint: disable=too-many-public-methods
     platform_name = "Slack"
     platform_slug = "slack"
 
@@ -286,9 +287,13 @@ class SlackDispatcher(Dispatcher):
         """
         choice_length = len(choices)
         if choice_length > self.slack_menu_limit:
-            self.send_warning(
-                f"More than {self.slack_menu_limit} options are available. Slack limits us to only displaying {self.slack_menu_limit} options at a time."
-            )
+            try:
+                # Since we are showing "Next..." at the end, this isn't required to show to users anymore
+                self.send_warning(
+                    f"More than {self.slack_menu_limit} options are available. Slack limits us to only displaying {self.slack_menu_limit} options at a time."
+                )
+            except SlackApiError:
+                pass
             new_offset = offset + self.slack_menu_limit - 1
             if offset == 0:
                 choices = choices[: self.slack_menu_limit - 1]  # 1 is to leave space for 'next' insert

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -273,7 +273,7 @@ class SlackDispatcher(Dispatcher):
         # In Slack, a textentry element can ONLY be sent in a modal dialog
         return self.send_blocks(blocks, callback_id=action_id, ephemeral=True, modal=True, title=title)
 
-    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices={}):
+    def prompt_from_menu(self, action_id, help_text, choices, offset=0, confirm_choices=None):
         """Prompt the user for a selection from a menu.
 
         Args:
@@ -286,6 +286,7 @@ class SlackDispatcher(Dispatcher):
             - default (tuple): Default (display, value) to pre-select.
             - confirm (bool): If True, prompt the user to confirm their selection (if the platform supports this)
         """
+        confirm_choices = confirm_choices or {}
         choice_length = len(choices)
         if choice_length > self.slack_menu_limit:
             self.send_warning(

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -38,7 +38,7 @@ class SlackDispatcher(Dispatcher):
         """Init a SlackDispatcher."""
         super().__init__(*args, **kwargs)
         self.slack_client = WebClient(token=settings.PLUGINS_CONFIG["nautobot_chatops"]["slack_api_token"])
-        self.slack_menu_limit = int(os.getenv("SLACK_MENU_LIMIT", 100))
+        self.slack_menu_limit = int(os.getenv("SLACK_MENU_LIMIT", "100"))
 
     @classmethod
     @BACKEND_ACTION_LOOKUP.time()

--- a/nautobot_chatops/tests/test_dispatchers.py
+++ b/nautobot_chatops/tests/test_dispatchers.py
@@ -8,6 +8,8 @@ from nautobot_chatops.dispatchers.slack import SlackDispatcher
 from nautobot_chatops.dispatchers.webex_teams import WebExTeamsDispatcher
 from nautobot_chatops.dispatchers.mattermost import MattermostDispatcher
 
+from slack.errors import SlackApiError
+
 
 class TestSlackDispatcher(TestCase):
     """Test the SlackDispatcher class."""
@@ -75,6 +77,47 @@ class TestSlackDispatcher(TestCase):
         self.assertNotEqual(element, None)
         self.assertIn("hello world!", str(element))
 
+    def test_prompt_from_menu_error(self):
+        """Make sure prompt_from_menu() errors out properly."""
+        with self.assertRaises(SlackApiError):
+            self.dispatcher.prompt_from_menu("action_id", "help_text", [])
+
+    def test_get_prompt_from_menu_choices(self):
+        """Make sure get_prompt_from_menu_choices() is implemented."""
+        choices = [("switch01", "switch01"), ("switch02", "switch02"), ("switch03", "switch03")]
+
+        response = self.dispatcher.get_prompt_from_menu_choices(choices)
+        self.assertEqual(response, choices)
+
+        choices = list()
+        for i in range(1, 101):
+            choices.append((f"switch{i}", f"switch{i}"))
+        response = self.dispatcher.get_prompt_from_menu_choices(choices)
+        self.assertEqual(response, choices)
+
+        choices = list()
+        for i in range(1, 511):
+            choices.append((f"switch{i}", f"switch{i}"))
+
+        expected_choices = choices[:99]
+        expected_choices.append(("Next...", "menu_offset-99"))
+        response = self.dispatcher.get_prompt_from_menu_choices(choices)
+        self.assertEqual(response, expected_choices)
+
+        expected_choices = choices[99:198]
+        expected_choices.append(("Next...", "menu_offset-198"))
+        response = self.dispatcher.get_prompt_from_menu_choices(choices, offset=99)
+        self.assertEqual(response, expected_choices)
+
+        expected_choices = choices[363:462]
+        expected_choices.append(("Next...", "menu_offset-462"))
+        response = self.dispatcher.get_prompt_from_menu_choices(choices, offset=363)
+        self.assertEqual(response, expected_choices)
+
+        expected_choices = choices[500:]
+        response = self.dispatcher.get_prompt_from_menu_choices(choices, offset=500)
+        self.assertEqual(response, expected_choices)
+
 
 class TestMSTeamsDispatcher(TestSlackDispatcher):
     """Test the MSTeamsDispatcher class."""
@@ -84,6 +127,14 @@ class TestMSTeamsDispatcher(TestSlackDispatcher):
     enable_opt_name = "enable_ms_teams"
 
     # Includes all of the test cases defined in TestSlackDispatcher, but uses MSTeamsDispatcher instead
+
+    def test_prompt_from_menu_error(self):
+        """Not implemented."""
+        pass
+
+    def test_get_prompt_from_menu_choices(self):
+        """Not implemented."""
+        pass
 
 
 class TestWebExTeamsDispatcher(TestSlackDispatcher):
@@ -95,6 +146,14 @@ class TestWebExTeamsDispatcher(TestSlackDispatcher):
 
     # Includes all of the test cases defined in TestSlackDispatcher, but uses WebExTeamsDispatcher instead
 
+    def test_prompt_from_menu_error(self):
+        """Not implemented."""
+        pass
+
+    def test_get_prompt_from_menu_choices(self):
+        """Not implemented."""
+        pass
+
 
 class TestMattermostDispatcher(TestSlackDispatcher):
     """Test the MattermostDispatcher class."""
@@ -104,3 +163,11 @@ class TestMattermostDispatcher(TestSlackDispatcher):
     enable_opt_name = "enable_mattermost"
 
     # Includes all of the test cases defined in TestSlackDispatcher, but uses MattermostDispatcher instead
+
+    def test_prompt_from_menu_error(self):
+        """Not implemented."""
+        pass
+
+    def test_get_prompt_from_menu_choices(self):
+        """Not implemented."""
+        pass

--- a/nautobot_chatops/workers/helper_functions.py
+++ b/nautobot_chatops/workers/helper_functions.py
@@ -1,0 +1,36 @@
+"""Helper functions for nautobot.py worker."""
+
+
+def is_menu_track_item(item):
+    """Return True if value starts with 'menu_track' for dealing with Slack menu display limit."""
+    try:
+        return item.startswith("menu_track-")
+    except AttributeError:
+        return False
+
+
+def menu_tracker_value(item):
+    """Return value of menu tracker if too many choices for Slack to handle."""
+    menu_tracker = 0
+    if item and is_menu_track_item(item):
+        menu_tracker = int(item.replace("menu_track-", ""))  # Index tracking when too many choices to display
+    return menu_tracker
+
+
+def add_asterisk(device, filter_type, value):
+    """Add asterisks to devices that are not of value `value` but are connected to those devices in the requested grouping."""
+    if filter_type == "all":
+        return str(device)
+    elif filter_type == "device":
+        return str(device)
+    elif filter_type == "site" and device.site == value:
+        return str(device)
+    elif filter_type == "role" and device.device_role == value:
+        return str(device)
+    elif filter_type == "region" and device.site.region == value:
+        return str(device)
+    elif filter_type == "model" and device.device_type == value:
+        return str(device)
+    else:
+        # Else, the device does not match the filter, so annotate it with an asterisk:
+        return f"*{device}"

--- a/nautobot_chatops/workers/helper_functions.py
+++ b/nautobot_chatops/workers/helper_functions.py
@@ -1,6 +1,15 @@
 """Helper functions for nautobot.py worker."""
 
 
+NETBOX_LOGO_PATH = "nautobot/NautobotLogoSquare.png"
+NETBOX_LOGO_ALT = "Nautobot Logo"
+
+
+def nautobot_logo(dispatcher):
+    """Construct an image_element containing the locally hosted Nautobot logo."""
+    return dispatcher.image_element(dispatcher.static_url(NETBOX_LOGO_PATH), alt_text=NETBOX_LOGO_ALT)
+
+
 def menu_item_check(item):
     """Return True if value starts with 'menu_offset' for dealing with Slack menu display limit."""
     if item:
@@ -36,3 +45,54 @@ def add_asterisk(device, filter_type, value):
     else:
         # Else, the device does not match the filter, so annotate it with an asterisk:
         return f"*{device}"
+
+
+def prompt_for_device_filter_type(action_id, help_text, dispatcher):
+    """Prompt the user to select a valid device filter type from a drop-down menu."""
+    choices = [
+        ("Name", "name"),
+        ("Site", "site"),
+        ("Role", "role"),
+        ("Model", "model"),
+        ("Manufacturer", "manufacturer"),
+    ]
+    return dispatcher.prompt_from_menu(action_id, help_text, choices)
+
+
+def prompt_for_interface_filter_type(action_id, help_text, dispatcher):
+    """Prompt the user to select a valid device filter type from a drop-down menu."""
+    choices = [
+        ("Device", "device"),
+        ("Model", "model"),
+        ("Region", "region"),
+        ("Role", "role"),
+        ("Site", "site"),
+        ("All (no filter)", "all"),
+    ]
+    return dispatcher.prompt_from_menu(action_id, help_text, choices)
+
+
+def prompt_for_vlan_filter_type(action_id, help_text, dispatcher):
+    """Prompt the user to select a valid VLAN filter type from a drop-down menu."""
+    choices = [
+        ("VLAN ID", "id"),
+        ("Group", "group"),
+        ("Name", "name"),
+        ("Role", "role"),
+        ("Site", "site"),
+        ("Status", "status"),
+        ("Tenant", "tenant"),
+        ("All (no filter)", "all"),
+    ]
+    return dispatcher.prompt_from_menu(action_id, help_text, choices)
+
+
+def prompt_for_circuit_filter_type(action_id, help_text, dispatcher):
+    """Prompt the user to select a valid device filter type from a drop-down menu."""
+    choices = [
+        ("Provider", "provider"),
+        ("Site", "site"),
+        ("Type", "type"),
+        ("All (no filter)", "all"),
+    ]
+    return dispatcher.prompt_from_menu(action_id, help_text, choices)

--- a/nautobot_chatops/workers/helper_functions.py
+++ b/nautobot_chatops/workers/helper_functions.py
@@ -1,20 +1,20 @@
 """Helper functions for nautobot.py worker."""
 
 
-def is_menu_track_item(item):
-    """Return True if value starts with 'menu_track' for dealing with Slack menu display limit."""
+def is_menu_offset_item(item):
+    """Return True if value starts with 'menu_offset' for dealing with Slack menu display limit."""
     try:
-        return item.startswith("menu_track-")
+        return item.startswith("menu_offset-")
     except AttributeError:
         return False
 
 
-def menu_tracker_value(item):
-    """Return value of menu tracker if too many choices for Slack to handle."""
-    menu_tracker = 0
-    if item and is_menu_track_item(item):
-        menu_tracker = int(item.replace("menu_track-", ""))  # Index tracking when too many choices to display
-    return menu_tracker
+def menu_offset_value(item):
+    """Return value of menu offset if too many choices for Slack to handle."""
+    menu_offset = 0
+    if item and is_menu_offset_item(item):
+        menu_offset = int(item.replace("menu_offset-", ""))  # Index tracking when too many choices to display
+    return menu_offset
 
 
 def add_asterisk(device, filter_type, value):

--- a/nautobot_chatops/workers/helper_functions.py
+++ b/nautobot_chatops/workers/helper_functions.py
@@ -1,18 +1,20 @@
 """Helper functions for nautobot.py worker."""
 
 
-def is_menu_offset_item(item):
+def menu_item_check(item):
     """Return True if value starts with 'menu_offset' for dealing with Slack menu display limit."""
-    try:
-        return item.startswith("menu_offset-")
-    except AttributeError:
-        return False
+    if item:
+        try:
+            return item.startswith("menu_offset-")
+        except AttributeError:
+            return False
+    return True
 
 
 def menu_offset_value(item):
     """Return value of menu offset if too many choices for Slack to handle."""
     menu_offset = 0
-    if item and is_menu_offset_item(item):
+    if item and menu_item_check(item):
         menu_offset = int(item.replace("menu_offset-", ""))  # Index tracking when too many choices to display
     return menu_offset
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -603,8 +603,8 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
 @subcommand_of("nautobot")
 def get_device_status(dispatcher, device_name):
     """Get the status of a device in Nautobot."""
-    if not device_name:
-        prompt_for_device("nautobot get-device-status", "Get Nautobot Device Status", dispatcher)
+    if not device_name or is_menu_track_item(device_name):
+        prompt_for_device("nautobot get-device-status", "Get Nautobot Device Status", dispatcher, tracker=menu_tracker_value(device_name))
         return False  # command did not run to completion and therefore should not be logged
 
     try:
@@ -632,8 +632,8 @@ def get_device_status(dispatcher, device_name):
 @subcommand_of("nautobot")
 def change_device_status(dispatcher, device_name, status):
     """Set the status of a device in Nautobot."""
-    if not device_name:
-        prompt_for_device("nautobot change-device-status", "Change Nautobot Device Status", dispatcher)
+    if not device_name or is_menu_track_item(device_name):
+        prompt_for_device("nautobot change-device-status", "Change Nautobot Device Status", dispatcher, tracker=menu_tracker_value(device_name))
         return False  # command did not run to completion and therefore should not be logged
 
     try:
@@ -643,13 +643,14 @@ def change_device_status(dispatcher, device_name, status):
         prompt_for_device("nautobot change-device-status", "Change Nautobot Device Status", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if not status:
+    if not status or is_menu_track_item(status):
+        confirm_choices = {"default": (device.status.name, device.status.slug), "confirm": True}
         dispatcher.prompt_from_menu(
             f"nautobot change-device-status {device_name}",
             f"Change Nautobot Device Status for {device_name}",
             [(choice[1], choice[0]) for choice in DeviceStatusChoices.CHOICES],
-            default=(device.status.name, device.status.slug),
-            confirm=True,
+            confirm_choices=confirm_choices,
+            tracker=menu_tracker_value(status)
         )
         return False  # command did not run to completion and therefore should not be logged
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -417,16 +417,24 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
                 f'Unknown filter type "{filter_type}"',
             )  # command did not run to completion and therefore should not be logged
 
-        if filter_type != "device":
+        if filter_type != "device" or is_menu_track_item(filter_type):
             dispatcher.prompt_from_menu(
-                f"nautobot get-interface-connections {filter_type}", f"Select a {filter_type}", choices
+                f"nautobot get-interface-connections {filter_type}",
+                f"Select a {filter_type}",
+                choices,
+                tracker=menu_tracker_value(filter_type),
             )
         else:
-            dispatcher.prompt_from_menu(f"nautobot get-interface-connections {filter_type}", "Select a site", choices)
+            dispatcher.prompt_from_menu(
+                f"nautobot get-interface-connections {filter_type}",
+                "Select a site",
+                choices,
+                tracker=menu_tracker_value(filter_type),
+            )
         return False  # command did not run to completion and therefore should not be logged
 
     # 3 param slash command
-    if filter_type == "device" and not filter_value_2:
+    if filter_type == "device" and (not filter_value_2 or is_menu_track_item(filter_value_2)):
         try:
             site = Site.objects.get(slug=filter_value_1)
         except Site.DoesNotExist:
@@ -438,7 +446,10 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
 
         device_options = [(device.name, str(device.name)) for device in Device.objects.filter(site=site)]
         dispatcher.prompt_from_menu(
-            f"nautobot get-interface-connections {filter_type} {filter_value_1}", "Select a device", device_options
+            f"nautobot get-interface-connections {filter_type} {filter_value_1}",
+            "Select a device",
+            device_options,
+            tracker=menu_tracker_value(filter_value_2),
         )
         return False
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -15,6 +15,7 @@ from nautobot.extras.models import Status
 
 from nautobot_chatops.choices import CommandStatusChoices
 from nautobot_chatops.workers import subcommand_of, handle_subcommands
+from nautobot_chatops.workers.helper_functions import add_asterisk, is_menu_track_item, menu_tracker_value
 
 
 NETBOX_LOGO_PATH = "nautobot/NautobotLogoSquare.png"
@@ -25,22 +26,6 @@ NETBOX_LOGO_ALT = "Nautobot Logo"
 def nautobot(subcommand, **kwargs):
     """Interact with Nautobot."""
     return handle_subcommands("nautobot", subcommand, **kwargs)
-
-
-def is_menu_track_item(item):
-    """Return True if value starts with 'menu_track' for dealing with Slack menu display limit."""
-    try:
-        return item.startswith("menu_track-")
-    except AttributeError:
-        return False
-
-
-def menu_tracker_value(item):
-    """Return value of menu tracker if too many choices for Slack to handle."""
-    menu_tracker = 0
-    if item and is_menu_track_item(item):
-        menu_tracker = int(item.replace("menu_track-", ""))  # Index tracking when too many choices to display
-    return menu_tracker
 
 
 def prompt_for_device(action_id, help_text, dispatcher, devices=None, tracker=0):
@@ -113,25 +98,6 @@ def prompt_for_vlan_filter_type(action_id, help_text, dispatcher):
 def nautobot_logo(dispatcher):
     """Construct an image_element containing the locally hosted Nautobot logo."""
     return dispatcher.image_element(dispatcher.static_url(NETBOX_LOGO_PATH), alt_text=NETBOX_LOGO_ALT)
-
-
-def add_asterisk(device, filter_type, value):
-    """Add asterisks to devices that are not of value `value` but are connected to those devices in the requested grouping."""
-    if filter_type == "all":
-        return str(device)
-    elif filter_type == "device":
-        return str(device)
-    elif filter_type == "site" and device.site == value:
-        return str(device)
-    elif filter_type == "role" and device.device_role == value:
-        return str(device)
-    elif filter_type == "region" and device.site.region == value:
-        return str(device)
-    elif filter_type == "model" and device.device_type == value:
-        return str(device)
-    else:
-        # Else, the device does not match the filter, so annotate it with an asterisk:
-        return f"*{device}"
 
 
 def send_interface_connection_table(dispatcher, connections, filter_type, value):

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -15,7 +15,7 @@ from nautobot.extras.models import Status
 
 from nautobot_chatops.choices import CommandStatusChoices
 from nautobot_chatops.workers import subcommand_of, handle_subcommands
-from nautobot_chatops.workers.helper_functions import add_asterisk, is_menu_track_item, menu_tracker_value
+from nautobot_chatops.workers.helper_functions import add_asterisk, is_menu_offset_item, menu_offset_value
 
 
 NETBOX_LOGO_PATH = "nautobot/NautobotLogoSquare.png"
@@ -28,7 +28,7 @@ def nautobot(subcommand, **kwargs):
     return handle_subcommands("nautobot", subcommand, **kwargs)
 
 
-def prompt_for_device(action_id, help_text, dispatcher, devices=None, tracker=0):
+def prompt_for_device(action_id, help_text, dispatcher, devices=None, offset=0):
     """Prompt the user to select a valid device from a drop-down menu."""
     # In the previous implementation, we grouped the devices into subgroups by site.
     # Unfortunately, while this is possible in Slack, the Adaptive Cards spec (MS Teams / WebEx Teams) can't do it.
@@ -38,7 +38,7 @@ def prompt_for_device(action_id, help_text, dispatcher, devices=None, tracker=0)
         dispatcher.send_error("No devices were found")
         return (CommandStatusChoices.STATUS_FAILED, "No devices found")
     choices = [(f"{device.site.name}: {device.name}", device.name) for device in devices]
-    return dispatcher.prompt_from_menu(action_id, help_text, choices, tracker=tracker)
+    return dispatcher.prompt_from_menu(action_id, help_text, choices, offset=offset)
 
 
 def prompt_for_vlan(action_id, help_text, dispatcher, filter_type, filter_value_1, vlans=None):
@@ -52,7 +52,7 @@ def prompt_for_vlan(action_id, help_text, dispatcher, filter_type, filter_value_
         choices = [(f"{vlan.vid}: {vlan.name}", str(vlan.vid)) for vlan in vlans]
     else:
         choices = [(vlan.name, vlan.name) for vlan in vlans]
-    return dispatcher.prompt_from_menu(action_id, help_text, choices, tracker=menu_tracker_value(filter_value_1))
+    return dispatcher.prompt_from_menu(action_id, help_text, choices, offset=menu_offset_value(filter_value_1))
 
 
 def prompt_for_device_filter_type(action_id, help_text, dispatcher):
@@ -177,7 +177,7 @@ def get_vlans(dispatcher, filter_type, filter_value_1):
     if not filter_type:
         prompt_for_vlan_filter_type("nautobot get-vlans", "select a vlan filter", dispatcher)
         return False
-    if not filter_value_1 or is_menu_track_item(filter_value_1):
+    if not filter_value_1 or is_menu_offset_item(filter_value_1):
         # One parameter Slash Command All
         if filter_type == "all":
             vlans = VLAN.objects.all()
@@ -245,7 +245,7 @@ def get_vlans(dispatcher, filter_type, filter_value_1):
             f"nautobot get-vlans {filter_type}",
             f"Select a {filter_type}",
             choices,
-            tracker=menu_tracker_value(filter_value_1),
+            offset=menu_offset_value(filter_value_1),
         )
         return False
 
@@ -417,24 +417,24 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
                 f'Unknown filter type "{filter_type}"',
             )  # command did not run to completion and therefore should not be logged
 
-        if filter_type != "device" or is_menu_track_item(filter_type):
+        if filter_type != "device" or is_menu_offset_item(filter_type):
             dispatcher.prompt_from_menu(
                 f"nautobot get-interface-connections {filter_type}",
                 f"Select a {filter_type}",
                 choices,
-                tracker=menu_tracker_value(filter_type),
+                offset=menu_offset_value(filter_type),
             )
         else:
             dispatcher.prompt_from_menu(
                 f"nautobot get-interface-connections {filter_type}",
                 "Select a site",
                 choices,
-                tracker=menu_tracker_value(filter_type),
+                offset=menu_offset_value(filter_type),
             )
         return False  # command did not run to completion and therefore should not be logged
 
     # 3 param slash command
-    if filter_type == "device" and (not filter_value_2 or is_menu_track_item(filter_value_2)):
+    if filter_type == "device" and (not filter_value_2 or is_menu_offset_item(filter_value_2)):
         try:
             site = Site.objects.get(slug=filter_value_1)
         except Site.DoesNotExist:
@@ -449,7 +449,7 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
             f"nautobot get-interface-connections {filter_type} {filter_value_1}",
             "Select a device",
             device_options,
-            tracker=menu_tracker_value(filter_value_2),
+            offset=menu_offset_value(filter_value_2),
         )
         return False
 
@@ -580,12 +580,12 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
 @subcommand_of("nautobot")
 def get_device_status(dispatcher, device_name):
     """Get the status of a device in Nautobot."""
-    if not device_name or is_menu_track_item(device_name):
+    if not device_name or is_menu_offset_item(device_name):
         prompt_for_device(
             "nautobot get-device-status",
             "Get Nautobot Device Status",
             dispatcher,
-            tracker=menu_tracker_value(device_name),
+            offset=menu_offset_value(device_name),
         )
         return False  # command did not run to completion and therefore should not be logged
 
@@ -614,12 +614,12 @@ def get_device_status(dispatcher, device_name):
 @subcommand_of("nautobot")
 def change_device_status(dispatcher, device_name, status):
     """Set the status of a device in Nautobot."""
-    if not device_name or is_menu_track_item(device_name):
+    if not device_name or is_menu_offset_item(device_name):
         prompt_for_device(
             "nautobot change-device-status",
             "Change Nautobot Device Status",
             dispatcher,
-            tracker=menu_tracker_value(device_name),
+            offset=menu_offset_value(device_name),
         )
         return False  # command did not run to completion and therefore should not be logged
 
@@ -670,12 +670,12 @@ def change_device_status(dispatcher, device_name, status):
 def get_device_facts(dispatcher, device_name):
     """Get detailed facts about a device from Nautobot in YAML format."""
 
-    if not device_name or is_menu_track_item(device_name):
+    if not device_name or is_menu_offset_item(device_name):
         prompt_for_device(
             "nautobot get-device-facts",
             "Get Nautobot Device Facts",
             dispatcher,
-            tracker=menu_tracker_value(device_name),
+            offset=menu_offset_value(device_name),
         )
         return False  # command did not run to completion and therefore should not be logged
 
@@ -720,7 +720,7 @@ def get_devices(dispatcher, filter_type, filter_value):
         prompt_for_device_filter_type("nautobot get-devices", "Select a device filter", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if not filter_value or is_menu_track_item(filter_value):
+    if not filter_value or is_menu_offset_item(filter_value):
         if filter_type == "name":
             dispatcher.prompt_for_text(f"nautobot get-devices {filter_type}", "Enter device name", "Device name")
             return False  # command did not run to completion and therefore should not be logged
@@ -744,7 +744,7 @@ def get_devices(dispatcher, filter_type, filter_value):
             f"nautobot get-devices {filter_type}",
             f"Select a {filter_type}",
             choices,
-            tracker=menu_tracker_value(filter_value),
+            offset=menu_offset_value(filter_value),
         )
         return False  # command did not run to completion and therefore should not be logged
 
@@ -822,7 +822,7 @@ def get_devices(dispatcher, filter_type, filter_value):
 @subcommand_of("nautobot")
 def get_rack(dispatcher, site_slug, rack_id):
     """Get information about a specific rack from Nautobot."""
-    if not site_slug or is_menu_track_item(site_slug):
+    if not site_slug or is_menu_offset_item(site_slug):
         # Only include sites with a non-zero number of racks
         site_options = [
             (site.name, site.slug) for site in Site.objects.annotate(Count("racks")).filter(racks__count__gt=0)
@@ -831,7 +831,7 @@ def get_rack(dispatcher, site_slug, rack_id):
             dispatcher.send_error("No sites with associated racks were found")
             return (CommandStatusChoices.STATUS_SUCCEEDED, "No sites with associated racks were found")
         dispatcher.prompt_from_menu(
-            "nautobot get-rack", "Select a site", site_options, tracker=menu_tracker_value(site_slug)
+            "nautobot get-rack", "Select a site", site_options, offset=menu_offset_value(site_slug)
         )
         return False  # command did not run to completion and therefore should not be logged
 
@@ -841,13 +841,13 @@ def get_rack(dispatcher, site_slug, rack_id):
         dispatcher.send_error(f"Site {site_slug} not found")
         return (CommandStatusChoices.STATUS_FAILED, f'Site "{site_slug}" not found')
 
-    if not rack_id or is_menu_track_item(rack_id):
+    if not rack_id or is_menu_offset_item(rack_id):
         rack_options = [(rack.name, str(rack.id)) for rack in Rack.objects.filter(site=site)]
         if not rack_options:
             dispatcher.send_error(f"No racks associated with site {site_slug} were found")
             return (CommandStatusChoices.STATUS_SUCCEEDED, f'No racks found for site "{site_slug}"')
         dispatcher.prompt_from_menu(
-            f"nautobot get-rack {site_slug}", "Select a rack", rack_options, tracker=menu_tracker_value(rack_id)
+            f"nautobot get-rack {site_slug}", "Select a rack", rack_options, offset=menu_offset_value(rack_id)
         )
         return False  # command did not run to completion and therefore should not be logged
 
@@ -899,7 +899,7 @@ def get_circuits(dispatcher, filter_type, filter_value):
         prompt_for_circuit_filter_type("nautobot get-circuits", "Select a circuit filter", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if filter_type != "all" and (not filter_value or is_menu_track_item(filter_value)):
+    if filter_type != "all" and (not filter_value or is_menu_offset_item(filter_value)):
         if filter_type == "type":
             choices = [(ctype.name, ctype.slug) for ctype in CircuitType.objects.all()]
         elif filter_type == "provider":
@@ -918,7 +918,7 @@ def get_circuits(dispatcher, filter_type, filter_value):
             f"nautobot get-circuits {filter_type}",
             f"Select a circuit {filter_type}",
             choices,
-            tracker=menu_tracker_value(filter_value),
+            offset=menu_offset_value(filter_value),
         )
         return False  # command did not run to completion and therefore should not be logged
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -591,12 +591,12 @@ def change_device_status(dispatcher, device_name, status):
         return False  # command did not run to completion and therefore should not be logged
 
     if menu_item_check(status):
-        confirm_choices = {"default": (device.status.name, device.status.slug), "confirm": True}
         dispatcher.prompt_from_menu(
             f"nautobot change-device-status {device_name}",
             f"Change Nautobot Device Status for {device_name}",
             [(choice[1], choice[0]) for choice in DeviceStatusChoices.CHOICES],
-            confirm_choices=confirm_choices,
+            default=(device.status.name, device.status.slug),
+            confirm=True,
             offset=menu_offset_value(status),
         )
         return False  # command did not run to completion and therefore should not be logged

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -27,7 +27,6 @@ def nautobot(subcommand, **kwargs):
     return handle_subcommands("nautobot", subcommand, **kwargs)
 
 
-# TODO Wed morning: Left off here.  need to test get-device-facts, then get-devices, then all others that I haven't tested yet
 def is_menu_track_item(item):
     """Return True if value starts with 'menu_track' for dealing with Slack menu display limit."""
     try:
@@ -68,7 +67,7 @@ def prompt_for_vlan(action_id, help_text, dispatcher, filter_type, vlans=None):
         choices = [(f"{vlan.vid}: {vlan.name}", str(vlan.vid)) for vlan in vlans]
     else:
         choices = [(vlan.name, vlan.name) for vlan in vlans]
-    return dispatcher.prompt_from_menu(action_id, help_text, choices, tracker=menu_tracker_value(device_name))
+    return dispatcher.prompt_from_menu(action_id, help_text, choices)
 
 
 def prompt_for_device_filter_type(action_id, help_text, dispatcher):
@@ -212,7 +211,7 @@ def get_vlans(dispatcher, filter_type, filter_value_1):
     if not filter_type:
         prompt_for_vlan_filter_type("nautobot get-vlans", "select a vlan filter", dispatcher)
         return False
-    if not filter_value_1 or is_menu_track_item(filter_value_1):
+    if not filter_value_1:
         # One parameter Slash Command All
         if filter_type == "all":
             vlans = VLAN.objects.all()
@@ -268,7 +267,7 @@ def get_vlans(dispatcher, filter_type, filter_value_1):
                 f'VLAN "{filter_type}" "{filter_value_1}" not found',
             )
 
-        dispatcher.prompt_from_menu(f"nautobot get-vlans {filter_type}", f"Select a {filter_type}", choices, tracker=menu_tracker_value(filter_value_1))
+        dispatcher.prompt_from_menu(f"nautobot get-vlans {filter_type}", f"Select a {filter_type}", choices)
         return False
 
     if filter_type == "name":
@@ -631,14 +630,13 @@ def change_device_status(dispatcher, device_name, status):
         prompt_for_device("nautobot change-device-status", "Change Nautobot Device Status", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if not status or is_menu_track_item(status):
+    if not status:
         dispatcher.prompt_from_menu(
             f"nautobot change-device-status {device_name}",
             f"Change Nautobot Device Status for {device_name}",
             [(choice[1], choice[0]) for choice in DeviceStatusChoices.CHOICES],
             default=(device.status.name, device.status.slug),
             confirm=True,
-            tracker=menu_tracker_value(status),
         )
         return False  # command did not run to completion and therefore should not be logged
 
@@ -667,7 +665,6 @@ def change_device_status(dispatcher, device_name, status):
     return CommandStatusChoices.STATUS_SUCCEEDED
 
 
-# TODO: Left off here.  works for get-device-facts.  need to make work for sites, then all other commands that use menus
 @subcommand_of("nautobot")
 def get_device_facts(dispatcher, device_name):
     """Get detailed facts about a device from Nautobot in YAML format."""
@@ -887,7 +884,7 @@ def get_circuits(dispatcher, filter_type, filter_value):
         prompt_for_circuit_filter_type("nautobot get-circuits", "Select a circuit filter", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if (filter_type != "all" and not filter_value) or is_menu_track_item(filter_value):
+    if filter_type != "all" and not filter_value:
         if filter_type == "type":
             choices = [(ctype.name, ctype.slug) for ctype in CircuitType.objects.all()]
         elif filter_type == "provider":
@@ -902,7 +899,7 @@ def get_circuits(dispatcher, filter_type, filter_value):
             dispatcher.send_error(f"No matching entries found for {filter_type}")
             return (CommandStatusChoices.STATUS_SUCCEEDED, f'No matching entries found for "{filter_type}"')
 
-        dispatcher.prompt_from_menu(f"nautobot get-circuits {filter_type}", f"Select a circuit {filter_type}", choices, tracker=menu_tracker_value(filter_value))
+        dispatcher.prompt_from_menu(f"nautobot get-circuits {filter_type}", f"Select a circuit {filter_type}", choices)
         return False  # command did not run to completion and therefore should not be logged
 
     if filter_type == "all":

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -630,14 +630,14 @@ def change_device_status(dispatcher, device_name, status):
         prompt_for_device("nautobot change-device-status", "Change Nautobot Device Status", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if not status or is_menu_track_item(status):
+    if not status or is_menu_offset_item(status):
         confirm_choices = {"default": (device.status.name, device.status.slug), "confirm": True}
         dispatcher.prompt_from_menu(
             f"nautobot change-device-status {device_name}",
             f"Change Nautobot Device Status for {device_name}",
             [(choice[1], choice[0]) for choice in DeviceStatusChoices.CHOICES],
             confirm_choices=confirm_choices,
-            tracker=menu_tracker_value(status),
+            offset=menu_offset_value(status),
         )
         return False  # command did not run to completion and therefore should not be logged
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -229,12 +229,20 @@ def get_vlans(dispatcher, filter_type, filter_value_1):
         # Two parameter Slash Commands
         elif filter_type == "id":
             prompt_for_vlan(
-                f"nautobot get-vlans {filter_type}", f"select a vlan {filter_type}", dispatcher, filter_type, filter_value_1
+                f"nautobot get-vlans {filter_type}",
+                f"select a vlan {filter_type}",
+                dispatcher,
+                filter_type,
+                filter_value_1,
             )
             return False
         elif filter_type == "name":
             prompt_for_vlan(
-                f"nautobot get-vlans {filter_type}", f"select a vlan {filter_type}", dispatcher, filter_type, filter_value_1
+                f"nautobot get-vlans {filter_type}",
+                f"select a vlan {filter_type}",
+                dispatcher,
+                filter_type,
+                filter_value_1,
             )
             return False
         elif filter_type == "status":
@@ -267,7 +275,12 @@ def get_vlans(dispatcher, filter_type, filter_value_1):
                 f'VLAN "{filter_type}" "{filter_value_1}" not found',
             )
 
-        dispatcher.prompt_from_menu(f"nautobot get-vlans {filter_type}", f"Select a {filter_type}", choices, tracker=menu_tracker_value(filter_value_1))
+        dispatcher.prompt_from_menu(
+            f"nautobot get-vlans {filter_type}",
+            f"Select a {filter_type}",
+            choices,
+            tracker=menu_tracker_value(filter_value_1),
+        )
         return False
 
     if filter_type == "name":
@@ -670,7 +683,12 @@ def get_device_facts(dispatcher, device_name):
     """Get detailed facts about a device from Nautobot in YAML format."""
 
     if not device_name or is_menu_track_item(device_name):
-        prompt_for_device("nautobot get-device-facts", "Get Nautobot Device Facts", dispatcher, tracker=menu_tracker_value(device_name))
+        prompt_for_device(
+            "nautobot get-device-facts",
+            "Get Nautobot Device Facts",
+            dispatcher,
+            tracker=menu_tracker_value(device_name),
+        )
         return False  # command did not run to completion and therefore should not be logged
 
     try:
@@ -734,7 +752,12 @@ def get_devices(dispatcher, filter_type, filter_value):
             dispatcher.send_error("No data found to filter by")
             return (CommandStatusChoices.STATUS_SUCCEEDED, f'No "{filter_type}" data found')
 
-        dispatcher.prompt_from_menu(f"nautobot get-devices {filter_type}", f"Select a {filter_type}", choices, tracker=menu_tracker_value(filter_value))
+        dispatcher.prompt_from_menu(
+            f"nautobot get-devices {filter_type}",
+            f"Select a {filter_type}",
+            choices,
+            tracker=menu_tracker_value(filter_value),
+        )
         return False  # command did not run to completion and therefore should not be logged
 
     if filter_type == "name":
@@ -819,7 +842,9 @@ def get_rack(dispatcher, site_slug, rack_id):
         if not site_options:
             dispatcher.send_error("No sites with associated racks were found")
             return (CommandStatusChoices.STATUS_SUCCEEDED, "No sites with associated racks were found")
-        dispatcher.prompt_from_menu("nautobot get-rack", "Select a site", site_options, tracker=menu_tracker_value(site_slug))
+        dispatcher.prompt_from_menu(
+            "nautobot get-rack", "Select a site", site_options, tracker=menu_tracker_value(site_slug)
+        )
         return False  # command did not run to completion and therefore should not be logged
 
     try:
@@ -833,7 +858,9 @@ def get_rack(dispatcher, site_slug, rack_id):
         if not rack_options:
             dispatcher.send_error(f"No racks associated with site {site_slug} were found")
             return (CommandStatusChoices.STATUS_SUCCEEDED, f'No racks found for site "{site_slug}"')
-        dispatcher.prompt_from_menu(f"nautobot get-rack {site_slug}", "Select a rack", rack_options, tracker=menu_tracker_value(rack_id))
+        dispatcher.prompt_from_menu(
+            f"nautobot get-rack {site_slug}", "Select a rack", rack_options, tracker=menu_tracker_value(rack_id)
+        )
         return False  # command did not run to completion and therefore should not be logged
 
     try:
@@ -899,7 +926,12 @@ def get_circuits(dispatcher, filter_type, filter_value):
             dispatcher.send_error(f"No matching entries found for {filter_type}")
             return (CommandStatusChoices.STATUS_SUCCEEDED, f'No matching entries found for "{filter_type}"')
 
-        dispatcher.prompt_from_menu(f"nautobot get-circuits {filter_type}", f"Select a circuit {filter_type}", choices, tracker=menu_tracker_value(filter_value))
+        dispatcher.prompt_from_menu(
+            f"nautobot get-circuits {filter_type}",
+            f"Select a circuit {filter_type}",
+            choices,
+            tracker=menu_tracker_value(filter_value),
+        )
         return False  # command did not run to completion and therefore should not be logged
 
     if filter_type == "all":

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -15,11 +15,7 @@ from nautobot.extras.models import Status
 
 from nautobot_chatops.choices import CommandStatusChoices
 from nautobot_chatops.workers import subcommand_of, handle_subcommands
-from nautobot_chatops.workers.helper_functions import add_asterisk, menu_item_check, menu_offset_value
-
-
-NETBOX_LOGO_PATH = "nautobot/NautobotLogoSquare.png"
-NETBOX_LOGO_ALT = "Nautobot Logo"
+from nautobot_chatops.workers.helper_functions import *
 
 
 @job("default")
@@ -53,51 +49,6 @@ def prompt_for_vlan(action_id, help_text, dispatcher, filter_type, filter_value_
     else:
         choices = [(vlan.name, vlan.name) for vlan in vlans]
     return dispatcher.prompt_from_menu(action_id, help_text, choices, offset=menu_offset_value(filter_value_1))
-
-
-def prompt_for_device_filter_type(action_id, help_text, dispatcher):
-    """Prompt the user to select a valid device filter type from a drop-down menu."""
-    choices = [
-        ("Name", "name"),
-        ("Site", "site"),
-        ("Role", "role"),
-        ("Model", "model"),
-        ("Manufacturer", "manufacturer"),
-    ]
-    return dispatcher.prompt_from_menu(action_id, help_text, choices)
-
-
-def prompt_for_interface_filter_type(action_id, help_text, dispatcher):
-    """Prompt the user to select a valid device filter type from a drop-down menu."""
-    choices = [
-        ("Device", "device"),
-        ("Model", "model"),
-        ("Region", "region"),
-        ("Role", "role"),
-        ("Site", "site"),
-        ("All (no filter)", "all"),
-    ]
-    return dispatcher.prompt_from_menu(action_id, help_text, choices)
-
-
-def prompt_for_vlan_filter_type(action_id, help_text, dispatcher):
-    """Prompt the user to select a valid VLAN filter type from a drop-down menu."""
-    choices = [
-        ("VLAN ID", "id"),
-        ("Group", "group"),
-        ("Name", "name"),
-        ("Role", "role"),
-        ("Site", "site"),
-        ("Status", "status"),
-        ("Tenant", "tenant"),
-        ("All (no filter)", "all"),
-    ]
-    return dispatcher.prompt_from_menu(action_id, help_text, choices)
-
-
-def nautobot_logo(dispatcher):
-    """Construct an image_element containing the locally hosted Nautobot logo."""
-    return dispatcher.image_element(dispatcher.static_url(NETBOX_LOGO_PATH), alt_text=NETBOX_LOGO_ALT)
 
 
 def send_interface_connection_table(dispatcher, connections, filter_type, value):
@@ -880,17 +831,6 @@ def get_rack(dispatcher, site_slug, rack_id):
     table = "\n".join(f"{unit['id']:2d} | {unit['device'].name if unit['device'] else ''}" for unit in units)
     dispatcher.send_snippet(table)
     return CommandStatusChoices.STATUS_SUCCEEDED
-
-
-def prompt_for_circuit_filter_type(action_id, help_text, dispatcher):
-    """Prompt the user to select a valid device filter type from a drop-down menu."""
-    choices = [
-        ("Provider", "provider"),
-        ("Site", "site"),
-        ("Type", "type"),
-        ("All (no filter)", "all"),
-    ]
-    return dispatcher.prompt_from_menu(action_id, help_text, choices)
 
 
 @subcommand_of("nautobot")

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -15,7 +15,7 @@ from nautobot.extras.models import Status
 
 from nautobot_chatops.choices import CommandStatusChoices
 from nautobot_chatops.workers import subcommand_of, handle_subcommands
-from nautobot_chatops.workers.helper_functions import add_asterisk, is_menu_offset_item, menu_offset_value
+from nautobot_chatops.workers.helper_functions import add_asterisk, menu_item_check, menu_offset_value
 
 
 NETBOX_LOGO_PATH = "nautobot/NautobotLogoSquare.png"
@@ -177,7 +177,7 @@ def get_vlans(dispatcher, filter_type, filter_value_1):
     if not filter_type:
         prompt_for_vlan_filter_type("nautobot get-vlans", "select a vlan filter", dispatcher)
         return False
-    if not filter_value_1 or is_menu_offset_item(filter_value_1):
+    if menu_item_check(filter_value_1):
         # One parameter Slash Command All
         if filter_type == "all":
             vlans = VLAN.objects.all()
@@ -417,7 +417,7 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
                 f'Unknown filter type "{filter_type}"',
             )  # command did not run to completion and therefore should not be logged
 
-        if filter_type != "device" or is_menu_offset_item(filter_type):
+        if filter_type != "device" or menu_item_check(filter_type):
             dispatcher.prompt_from_menu(
                 f"nautobot get-interface-connections {filter_type}",
                 f"Select a {filter_type}",
@@ -434,7 +434,7 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
         return False  # command did not run to completion and therefore should not be logged
 
     # 3 param slash command
-    if filter_type == "device" and (not filter_value_2 or is_menu_offset_item(filter_value_2)):
+    if filter_type == "device" and menu_item_check(filter_value_2):
         try:
             site = Site.objects.get(slug=filter_value_1)
         except Site.DoesNotExist:
@@ -580,7 +580,7 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
 @subcommand_of("nautobot")
 def get_device_status(dispatcher, device_name):
     """Get the status of a device in Nautobot."""
-    if not device_name or is_menu_offset_item(device_name):
+    if menu_item_check(device_name):
         prompt_for_device(
             "nautobot get-device-status",
             "Get Nautobot Device Status",
@@ -614,7 +614,7 @@ def get_device_status(dispatcher, device_name):
 @subcommand_of("nautobot")
 def change_device_status(dispatcher, device_name, status):
     """Set the status of a device in Nautobot."""
-    if not device_name or is_menu_offset_item(device_name):
+    if menu_item_check(device_name):
         prompt_for_device(
             "nautobot change-device-status",
             "Change Nautobot Device Status",
@@ -630,7 +630,7 @@ def change_device_status(dispatcher, device_name, status):
         prompt_for_device("nautobot change-device-status", "Change Nautobot Device Status", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if not status or is_menu_offset_item(status):
+    if menu_item_check(status):
         confirm_choices = {"default": (device.status.name, device.status.slug), "confirm": True}
         dispatcher.prompt_from_menu(
             f"nautobot change-device-status {device_name}",
@@ -670,7 +670,7 @@ def change_device_status(dispatcher, device_name, status):
 def get_device_facts(dispatcher, device_name):
     """Get detailed facts about a device from Nautobot in YAML format."""
 
-    if not device_name or is_menu_offset_item(device_name):
+    if menu_item_check(device_name):
         prompt_for_device(
             "nautobot get-device-facts",
             "Get Nautobot Device Facts",
@@ -720,7 +720,7 @@ def get_devices(dispatcher, filter_type, filter_value):
         prompt_for_device_filter_type("nautobot get-devices", "Select a device filter", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if not filter_value or is_menu_offset_item(filter_value):
+    if menu_item_check(filter_value):
         if filter_type == "name":
             dispatcher.prompt_for_text(f"nautobot get-devices {filter_type}", "Enter device name", "Device name")
             return False  # command did not run to completion and therefore should not be logged
@@ -822,7 +822,7 @@ def get_devices(dispatcher, filter_type, filter_value):
 @subcommand_of("nautobot")
 def get_rack(dispatcher, site_slug, rack_id):
     """Get information about a specific rack from Nautobot."""
-    if not site_slug or is_menu_offset_item(site_slug):
+    if menu_item_check(site_slug):
         # Only include sites with a non-zero number of racks
         site_options = [
             (site.name, site.slug) for site in Site.objects.annotate(Count("racks")).filter(racks__count__gt=0)
@@ -841,7 +841,7 @@ def get_rack(dispatcher, site_slug, rack_id):
         dispatcher.send_error(f"Site {site_slug} not found")
         return (CommandStatusChoices.STATUS_FAILED, f'Site "{site_slug}" not found')
 
-    if not rack_id or is_menu_offset_item(rack_id):
+    if menu_item_check(rack_id):
         rack_options = [(rack.name, str(rack.id)) for rack in Rack.objects.filter(site=site)]
         if not rack_options:
             dispatcher.send_error(f"No racks associated with site {site_slug} were found")
@@ -899,7 +899,7 @@ def get_circuits(dispatcher, filter_type, filter_value):
         prompt_for_circuit_filter_type("nautobot get-circuits", "Select a circuit filter", dispatcher)
         return False  # command did not run to completion and therefore should not be logged
 
-    if filter_type != "all" and (not filter_value or is_menu_offset_item(filter_value)):
+    if filter_type != "all" and menu_item_check(filter_value):
         if filter_type == "type":
             choices = [(ctype.name, ctype.slug) for ctype in CircuitType.objects.all()]
         elif filter_type == "provider":

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -15,7 +15,16 @@ from nautobot.extras.models import Status
 
 from nautobot_chatops.choices import CommandStatusChoices
 from nautobot_chatops.workers import subcommand_of, handle_subcommands
-from nautobot_chatops.workers.helper_functions import *
+from nautobot_chatops.workers.helper_functions import (
+    add_asterisk,
+    menu_offset_value,
+    nautobot_logo,
+    menu_item_check,
+    prompt_for_circuit_filter_type,
+    prompt_for_device_filter_type,
+    prompt_for_interface_filter_type,
+    prompt_for_vlan_filter_type,
+)
 
 
 @job("default")
@@ -620,7 +629,6 @@ def change_device_status(dispatcher, device_name, status):
 @subcommand_of("nautobot")
 def get_device_facts(dispatcher, device_name):
     """Get detailed facts about a device from Nautobot in YAML format."""
-
     if menu_item_check(device_name):
         prompt_for_device(
             "nautobot get-device-facts",

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -331,7 +331,7 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
             "nautobot get-interface-connections", "Select an interface connection filter", dispatcher
         )
         return False  # command did not run to completion and therefore should not be logged
-    if not filter_value_1:
+    if menu_item_check(filter_value_1):
         if ("device" or "site") in filter_type:
             # Since the device filter prompts the user to pick a site first in order to further query devices located in the chosen site, the device filter will start off with choices of all the sites with one or more devices.
             choices = [
@@ -377,19 +377,19 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
                 f'Unknown filter type "{filter_type}"',
             )  # command did not run to completion and therefore should not be logged
 
-        if filter_type != "device" or menu_item_check(filter_type):
+        if filter_type != "device":
             dispatcher.prompt_from_menu(
                 f"nautobot get-interface-connections {filter_type}",
                 f"Select a {filter_type}",
                 choices,
-                offset=menu_offset_value(filter_type),
+                offset=menu_offset_value(filter_value_1),
             )
         else:
             dispatcher.prompt_from_menu(
                 f"nautobot get-interface-connections {filter_type}",
                 "Select a site",
                 choices,
-                offset=menu_offset_value(filter_type),
+                offset=menu_offset_value(filter_value_1),
             )
         return False  # command did not run to completion and therefore should not be logged
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -570,7 +570,12 @@ def get_interface_connections(dispatcher, filter_type, filter_value_1, filter_va
 def get_device_status(dispatcher, device_name):
     """Get the status of a device in Nautobot."""
     if not device_name or is_menu_track_item(device_name):
-        prompt_for_device("nautobot get-device-status", "Get Nautobot Device Status", dispatcher, tracker=menu_tracker_value(device_name))
+        prompt_for_device(
+            "nautobot get-device-status",
+            "Get Nautobot Device Status",
+            dispatcher,
+            tracker=menu_tracker_value(device_name),
+        )
         return False  # command did not run to completion and therefore should not be logged
 
     try:
@@ -599,7 +604,12 @@ def get_device_status(dispatcher, device_name):
 def change_device_status(dispatcher, device_name, status):
     """Set the status of a device in Nautobot."""
     if not device_name or is_menu_track_item(device_name):
-        prompt_for_device("nautobot change-device-status", "Change Nautobot Device Status", dispatcher, tracker=menu_tracker_value(device_name))
+        prompt_for_device(
+            "nautobot change-device-status",
+            "Change Nautobot Device Status",
+            dispatcher,
+            tracker=menu_tracker_value(device_name),
+        )
         return False  # command did not run to completion and therefore should not be logged
 
     try:
@@ -616,7 +626,7 @@ def change_device_status(dispatcher, device_name, status):
             f"Change Nautobot Device Status for {device_name}",
             [(choice[1], choice[0]) for choice in DeviceStatusChoices.CHOICES],
             confirm_choices=confirm_choices,
-            tracker=menu_tracker_value(status)
+            tracker=menu_tracker_value(status),
         )
         return False  # command did not run to completion and therefore should not be logged
 


### PR DESCRIPTION
This PR is to fix issue #3.

Essentially this was the easiest way I could think of to add support for menu choices where there were more than 100 options without doing additional refactoring of how the dispatchers are written.

The default behavior in Slack now is if more than 100 choices are present, the last choice is replaced with the option `More...` for the user.  If the user selects `More...`, then the menu is redisplayed to the user with the next 100 choices.  If there are no more choices, `More...` doesn't appear.
