### PR TITLE
Fix site ordering for get-rack command filter

### DIFF
--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -70,11 +70,11 @@ def prompt_for_interface_filter_type(action_id, help_text, dispatcher):
     """Prompt the user to select a valid device filter type from a drop-down menu."""
     choices = [
         ("Device", "device"),
-        ("Site", "site"),
-        ("Role", "role"),
-        ("Region", "region"),
         ("Model", "model"),
-        ("All", "all"),
+        ("Region", "region"),
+        ("Role", "role"),
+        ("Site", "site"),
+        ("All (no filter)", "all"),
     ]
     return dispatcher.prompt_from_menu(action_id, help_text, choices)
 
@@ -83,13 +83,13 @@ def prompt_for_vlan_filter_type(action_id, help_text, dispatcher):
     """Prompt the user to select a valid VLAN filter type from a drop-down menu."""
     choices = [
         ("VLAN ID", "id"),
-        ("Site", "site"),
         ("Group", "group"),
         ("Name", "name"),
-        ("Tenant", "tenant"),
-        ("Status", "status"),
         ("Role", "role"),
-        ("All", "all"),
+        ("Site", "site"),
+        ("Status", "status"),
+        ("Tenant", "tenant"),
+        ("All (no filter)", "all"),
     ]
     return dispatcher.prompt_from_menu(action_id, help_text, choices)
 
@@ -852,10 +852,10 @@ def get_rack(dispatcher, site_slug, rack_id):
 def prompt_for_circuit_filter_type(action_id, help_text, dispatcher):
     """Prompt the user to select a valid device filter type from a drop-down menu."""
     choices = [
-        ("All (no filter)", "all"),
-        ("Type", "type"),
         ("Provider", "provider"),
         ("Site", "site"),
+        ("Type", "type"),
+        ("All (no filter)", "all"),
     ]
     return dispatcher.prompt_from_menu(action_id, help_text, choices)
 

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -797,7 +797,8 @@ def get_rack(dispatcher, site_slug, rack_id):
     if not site_slug:
         # Only include sites with a non-zero number of racks
         site_options = [
-            (site.name, site.slug) for site in Site.objects.annotate(Count("racks")).filter(racks__count__gt=0).order_by("name", "name")
+            (site.name, site.slug)
+            for site in Site.objects.annotate(Count("racks")).filter(racks__count__gt=0).order_by("name", "name")
         ]
         if not site_options:
             dispatcher.send_error("No sites with associated racks were found")

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -797,7 +797,7 @@ def get_rack(dispatcher, site_slug, rack_id):
     if not site_slug:
         # Only include sites with a non-zero number of racks
         site_options = [
-            (site.name, site.slug) for site in Site.objects.annotate(Count("racks")).filter(racks__count__gt=0)
+            (site.name, site.slug) for site in Site.objects.annotate(Count("racks")).filter(racks__count__gt=0).order_by("name", "name")
         ]
         if not site_options:
             dispatcher.send_error("No sites with associated racks were found")


### PR DESCRIPTION
This is a fix for issue #11 .

In addition, I've also rearranged a few of the static filters displayed to users to be consistent in their ordering, and to move any options for `All (no filter)` to the bottom.  Currently some filters have `All (no filter)` at the top, and others at the bottom.  This keeps it consistent across the board as well.