### PR TITLE
Add celery worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ python:
 
 env:
   - "INVOKE_NAUTOBOT_CHATOPS_NAUTOBOT_VER=1.0.2"
+  - "INVOKE_NAUTOBOT_CHATOPS_NAUTOBOT_VER=1.1.2"
 
 services:
   - "docker"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ python:
   - 3.8
 
 # Testing 1.0.3 as it is still pre-Celery, but has the choices test fix nautobot#457
+# 1.0.2 would also work, it would just skip the choices test.
 env:
   - "INVOKE_NAUTOBOT_CHATOPS_NAUTOBOT_VER=1.0.3"
   - "INVOKE_NAUTOBOT_CHATOPS_NAUTOBOT_VER=1.1.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ python:
   - 3.7
   - 3.8
 
+# Testing 1.0.3 as it is still pre-Celery, but has the choices test fix nautobot#457
 env:
-  - "INVOKE_NAUTOBOT_CHATOPS_NAUTOBOT_VER=1.0.2"
+  - "INVOKE_NAUTOBOT_CHATOPS_NAUTOBOT_VER=1.0.3"
   - "INVOKE_NAUTOBOT_CHATOPS_NAUTOBOT_VER=1.1.2"
 
 services:

--- a/development/docker-compose.celery.yml
+++ b/development/docker-compose.celery.yml
@@ -15,4 +15,3 @@ services:
     volumes:
       - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
       - "../:/source"
-

--- a/development/docker-compose.celery.yml
+++ b/development/docker-compose.celery.yml
@@ -7,7 +7,7 @@ services:
       - "dev.env"
       - "creds.env"
     tty: true
-    entrypoint: "nautobot-server celery worker -B -l INFO"
+    entrypoint: "nautobot-server celery worker -l INFO"
     depends_on:
       - "nautobot"
     healthcheck:

--- a/development/docker-compose.celery.yml
+++ b/development/docker-compose.celery.yml
@@ -1,0 +1,18 @@
+---
+version: "3.4"
+services:
+  celery:
+    image: "nautobot-chatops-plugin/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER}"
+    env_file:
+      - "dev.env"
+      - "creds.env"
+    tty: true
+    entrypoint: "nautobot-server celery worker -B -l INFO"
+    depends_on:
+      - "nautobot"
+    healthcheck:
+      disable: true
+    volumes:
+      - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
+      - "../:/source"
+

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -266,3 +266,7 @@ TIME_ZONE = os.environ.get("TIME_ZONE", "UTC")
 # Django Debug Toolbar
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG and not TESTING}
+#
+# Celery settings are not defined here because they can be overloaded with
+# environment variables. By default they use `CACHES["default"]["LOCATION"]`.
+#

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,6 +40,8 @@ provided `creds.env.example` file to `creds.env` and customizing the contents of
 
 ### Testing
 
+While the plugin itself supports any general release version of Nautobot, the testing requires at minimum 1.0.2.
+
 ```
   tests            Run all tests for this plugin.
   pylint           Run pylint code analysis.

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -1,6 +1,5 @@
 """Generic base class modeling the API for sending messages to a generic chat platform."""
 
-import copy
 import logging
 
 from django.templatetags.static import static

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -1,5 +1,6 @@
 """Generic base class modeling the API for sending messages to a generic chat platform."""
 
+import copy
 import logging
 
 from django.templatetags.static import static

--- a/nautobot_chatops/tests/test_api.py
+++ b/nautobot_chatops/tests/test_api.py
@@ -28,6 +28,7 @@ class CommandTokenTest(APIViewTestCases.APIViewTestCase):  # pylint: disable=too
         {"comment": "Test 6", "platform": "mattermost", "token": "token6"},
     ]
     bulk_update_data = {"comment": "Testing"}
+    choices_fields = ["platform"]
 
     @classmethod
     def setUpTestData(cls):
@@ -48,6 +49,7 @@ class AccessGrantTest(APIViewTestCases.APIViewTestCase):  # pylint: disable=too-
         {"command": "*", "subcommand": "*", "grant_type": "user", "name": "test6", "value": "*"},
     ]
     bulk_update_data = {"command": "nautobot"}
+    choices_fields = ["grant_type"]
 
     @classmethod
     def setUpTestData(cls):

--- a/nautobot_chatops/utils.py
+++ b/nautobot_chatops/utils.py
@@ -27,6 +27,8 @@ try:
         function, registry or dispatcher_class, we will have to look them up.
         """
         # import done here instead of up top to prevent circular imports.
+        # Disabling cyclic-import as this does not affect the worker.
+        # pylint: disable=import-outside-toplevel,cyclic-import
         from nautobot_chatops.workers import get_commands_registry
 
         registry = get_commands_registry()
@@ -43,16 +45,6 @@ except ImportError:
     from django_rq import get_queue
 
     CELERY_WORKER = False
-
-    def enqueue_task(function, subcommand, params, dispatcher_class, context):
-        """Enqueue task with Django RQ worker."""
-        return get_queue("default").enqueue(
-            function,
-            subcommand,
-            params=params,
-            dispatcher_class=dispatcher_class,
-            context=context,
-        )
 
 
 def create_command_log(dispatcher, registry, command, subcommand, params=()):
@@ -206,7 +198,7 @@ def check_and_enqueue_command(
             context=context,
         )
     else:
-        enqueue_task(
+        get_queue("default").enqueue(
             registry[command]["function"],
             subcommand,
             params=params,

--- a/nautobot_chatops/utils.py
+++ b/nautobot_chatops/utils.py
@@ -41,7 +41,6 @@ try:
 
     def enqueue_task(*, command, subcommand, params, dispatcher_class, context, **kwargs):
         """Enqueue task with Celery worker."""
-
         return celery_worker_task.delay(
             command,
             subcommand,
@@ -59,7 +58,6 @@ except ImportError:
 
     def enqueue_task(*, function, subcommand, params, dispatcher_class, context, **kwargs):
         """Enqueue task with Django RQ Worker."""
-
         return get_queue("default").enqueue(
             function,
             subcommand,

--- a/nautobot_chatops/utils.py
+++ b/nautobot_chatops/utils.py
@@ -36,11 +36,10 @@ try:
 
         return function(subcommand, params=params, dispatcher_class=dispatcher_class, context=context)
 
-    def enqueue_task(command, subcommand, params, dispatcher_class, context, function=None):
+    def enqueue_task(*, command, subcommand, params, dispatcher_class, context, **kwargs):
         """Enqueue task with Celery worker."""
         # Since celery can't deserialize class, we will discard function and
         # send the command instead.
-        _ = function
 
         return celery_worker_task.delay(
             command,
@@ -57,10 +56,9 @@ except ImportError:
 
     from django_rq import get_queue
 
-    def enqueue_task(command, subcommand, params, dispatcher_class, context, function=None):
+    def enqueue_task(*, function, subcommand, params, dispatcher_class, context, **kwargs):
         """Enqueue task with Django RQ Worker."""
         # RQ will handle passing the function, so we can discard the command.
-        _ = command
 
         return get_queue("default").enqueue(
             function,
@@ -213,8 +211,8 @@ def check_and_enqueue_command(
 
     # If we made it here, we're permitted. Enqueue it for the worker
     enqueue_task(
-        command,
-        subcommand,
+        command=command,
+        subcommand=subcommand,
         params=params,
         dispatcher_class=dispatcher_class,
         context=context,

--- a/nautobot_chatops/workers/base.py
+++ b/nautobot_chatops/workers/base.py
@@ -2,8 +2,15 @@
 
 Obsolete - contents of this file have been migrated to other modules.
 """
+import warnings
 
 # For backwards compatibility -- these used to be defined in this file
 # pylint: disable=unused-import
 from nautobot_chatops.utils import create_command_log
 from nautobot_chatops.workers import subcommand_of, handle_subcommands
+
+warnings.warn(
+    """Importing from `nautobot_chatops.workers.base` has been deprecated, please use `nautobot_chatops.workers`
+    for `subcommand_of` and `handle_subcommands` or `nautobot_chatops.utils` for `create_command_log`""",
+    DeprecationWarning,
+)

--- a/tasks.py
+++ b/tasks.py
@@ -35,7 +35,7 @@ def is_truthy(arg):
 # Use pyinvoke configuration for default values, see http://docs.pyinvoke.org/en/stable/concepts/configuration.html
 # Variables may be overwritten in invoke.yml or by the environment variables INVOKE_NAUTOBOT_CHATOPS_xxx
 
-# To test with celery support first run `poetry lock` to update your lock file, then 
+# To test with celery support first run `poetry lock` to update your lock file, then
 # change nautobot_ver to match the lock file and add docker-compose.celery.yml to the compose_files
 namespace = Collection("nautobot_chatops")
 namespace.configure(

--- a/tasks.py
+++ b/tasks.py
@@ -34,6 +34,9 @@ def is_truthy(arg):
 
 # Use pyinvoke configuration for default values, see http://docs.pyinvoke.org/en/stable/concepts/configuration.html
 # Variables may be overwritten in invoke.yml or by the environment variables INVOKE_NAUTOBOT_CHATOPS_xxx
+
+# To test with celery support first run `poetry lock` to update your lock file, then 
+# change nautobot_ver to match the lock file and add docker-compose.celery.yml to the compose_files
 namespace = Collection("nautobot_chatops")
 namespace.configure(
     {


### PR DESCRIPTION
FIXES: #64 

This PR adds support for Celery Worker.  Verified that backwards compatibility was maintained.  Confirmed with nautobot-plugin-chatops-ansible to ensure that none of the chat command plugins would need to be updated.

I decided to keep the development environment setup the way it is, to ensure changes going forward are still done with backwards compatibility (at least until Nautobot 2.0).  I am providing a docker-compose file with celery so that local testing could move over to that if the developer wishes.