### PR TITLE
Adds a hyperlink function for the chatops.

### DIFF
--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -236,6 +236,11 @@ class Dispatcher:
         return f"**{text}**"
 
     # pylint: disable=no-self-use
+    def hyperlink(self, text, url):
+        """Create Hyperlinks."""
+        return f"[{text}]({url})"
+
+    # pylint: disable=no-self-use
     def monospace(self, text):
         """Mark text as monospace."""
         return f"`{text}`"

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -410,6 +410,10 @@ class SlackDispatcher(Dispatcher):
         """Mark text as bold."""
         return f"*{text}*"
 
+    def hyperlink(self, text, url):
+        """Create Hyperlinks."""
+        return f"<{url}|{text}>"
+
     def actions_block(self, block_id, actions):
         """Construct a block consisting of a set of action elements."""
         return {"type": "actions", "block_id": block_id, "elements": actions}

--- a/nautobot_chatops/workers/nautobot.py
+++ b/nautobot_chatops/workers/nautobot.py
@@ -976,3 +976,15 @@ def get_circuit_providers(dispatcher, *args):
 
     dispatcher.send_large_table(header, rows)
     return CommandStatusChoices.STATUS_SUCCEEDED
+
+
+@subcommand_of("nautobot")
+def about(dispatcher, *args):
+    """Provide link for more information on Nautobot Apps."""
+    url = "https://www.networktocode.com/nautobot/apps/"
+    blocks = [
+        dispatcher.markdown_block(f"More Chat commands can be found at {dispatcher.hyperlink('Nautobot Apps', url)}"),
+    ]
+
+    dispatcher.send_blocks(blocks)
+    return CommandStatusChoices.STATUS_SUCCEEDED


### PR DESCRIPTION
FIXES: #65 

This provides a new function that can be used in markdown blocks.  Instead of trying to parse and format markdown, this takes the approach that the `bold` function does. Providing a method that can be adapted for each of the chat platforms.  Confirmed that all supported platforms can use this function. 

Also provides an example of the function in use.