### PR TITLE
Add 'session' data for Chatops to keep interesting state

### DIFF
--- a/docs/chat_setup/chat_setup.md
+++ b/docs/chat_setup/chat_setup.md
@@ -75,6 +75,7 @@ Note a few details about this example:
 * You must add `"nautobot_chatops"` to the list defined by `PLUGINS`
 * The `slack_api_token` and `slack_signing_secret` values were taken from the values presented in the Slack platform-specific setup.
 * Alternately, the `slack_api_token` and `slack_signing_secret` values could also be stored in an `.env` file, then referred to by those defined environment variables in `PLUGINS_CONFIG`.
+* Some commands can use a user's session cache to keep state for some data between commands (e.g. use the same target device between commands). By default, it keeps data for 86400 seconds, but with `session_cache_timeout` this value can be adjusted.
 
 ```python
 # Enable installed plugins. Add the name of each plugin to the list.
@@ -85,6 +86,7 @@ PLUGINS_CONFIG = {
         'enable_slack': True,
         'slack_api_token': 'xoxb-2078939598626-2078997105202-3QupQHVC3lEhyGtKPpK62fGB',
         'slack_signing_secret': '1be5e964569d52a2e74f13fcefb1213f',
+        'session_cache_timeout': 3600,
     }
 }
 ```

--- a/nautobot_chatops/__init__.py
+++ b/nautobot_chatops/__init__.py
@@ -27,6 +27,8 @@ class NautobotChatOpsConfig(PluginConfig):
         "enable_webex": False,
         # Should menus, text input fields, etc. be deleted from the chat history after the user makes a selection?
         "delete_input_on_submission": False,
+        # Session Cache
+        "session_cache_timeout": 86400,
         # Slack-specific settings
         "slack_api_token": None,  # for example, "xoxb-123456"
         "slack_signing_secret": None,

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -9,8 +9,6 @@ from texttable import Texttable
 
 logger = logging.getLogger("rq.worker")
 
-DEFAULT_SESSION_CACHE_TIMEOUT = 86400
-
 
 class Dispatcher:
     """Abstract base class for all chat-app dispatchers."""

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -1,6 +1,5 @@
 """Generic base class modeling the API for sending messages to a generic chat platform."""
 import logging
-import hashlib
 from django.templatetags.static import static
 from django.core.cache import cache
 from django.conf import settings
@@ -41,8 +40,7 @@ class Dispatcher:
     def _get_cache_key(self) -> str:
         """Key generator for the cache, adding the plugin prefix name."""
         # Using __file__ as a key customization within the cache
-        key_string = "-".join([__file__, self.context.get("user_name")])
-        return hashlib.md5(key_string.encode("utf-8")).hexdigest()  # nosec
+        return "-".join([__file__, self.context.get("user_id", "generic")])
 
     @property
     def session(self) -> dict:

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -9,6 +9,8 @@ from texttable import Texttable
 
 logger = logging.getLogger("rq.worker")
 
+DEFAULT_SESSION_CACHE_TIMEOUT = 86400
+
 
 class Dispatcher:
     """Abstract base class for all chat-app dispatchers."""
@@ -50,11 +52,23 @@ class Dispatcher:
     @session.setter
     def session(self, value: dict):
         """Set the session data for a user."""
-        cache.set(self._get_cache_key(), value, timeout=86400)
+        cache.set(
+            self._get_cache_key(),
+            value,
+            timeout=settings.PLUGINS_CONFIG["nautobot_chatops"].get(
+                "session_cache_timeout", DEFAULT_SESSION_CACHE_TIMEOUT
+            ),
+        )
 
     def update_session(self, updated_session: dict):
         """Update the session for a user."""
-        cache.set(self._get_cache_key(), {**self.session, **updated_session}, timeout=86400)
+        cache.set(
+            self._get_cache_key(),
+            {**self.session, **updated_session},
+            timeout=settings.PLUGINS_CONFIG["nautobot_chatops"].get(
+                "session_cache_timeout", DEFAULT_SESSION_CACHE_TIMEOUT
+            ),
+        )
 
     @classmethod
     def subclasses(cls):

--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -45,28 +45,22 @@ class Dispatcher:
 
     def get_session_entry(self, key: str):
         """Return the session data for a key."""
-        session_value = cache.get(self._get_cache_key()) or {}
-        try:
-            return session_value[key]
-        except KeyError:
-            return None
+        return cache.get(self._get_cache_key(), {}).get(key, None)
 
     def set_session_entry(self, key: str, value):
         """Set the session data for a key."""
-        session_value = cache.get(self._get_cache_key()) or {}
+        session_value = cache.get(self._get_cache_key(), {})
         session_value[key] = value
 
         cache.set(
             self._get_cache_key(),
             session_value,
-            timeout=settings.PLUGINS_CONFIG["nautobot_chatops"].get(
-                "session_cache_timeout", DEFAULT_SESSION_CACHE_TIMEOUT
-            ),
+            timeout=settings.PLUGINS_CONFIG["nautobot_chatops"]["session_cache_timeout"],
         )
 
     def unset_session_entry(self, key: str):
         """Unset a session data for a key."""
-        session_value = cache.get(self._get_cache_key()) or {}
+        session_value = cache.get(self._get_cache_key(), {})
         try:
             del session_value[key]
             self.set_session(session_value)
@@ -75,7 +69,7 @@ class Dispatcher:
 
     def get_session(self):
         """Return the whole session data."""
-        return cache.get(self._get_cache_key()) or {}
+        return cache.get(self._get_cache_key(), {})
 
     def set_session(self, value: Dict):
         """Set the whole session data."""
@@ -86,9 +80,7 @@ class Dispatcher:
         cache.set(
             self._get_cache_key(),
             session_value,
-            timeout=settings.PLUGINS_CONFIG["nautobot_chatops"].get(
-                "session_cache_timeout", DEFAULT_SESSION_CACHE_TIMEOUT
-            ),
+            timeout=settings.PLUGINS_CONFIG["nautobot_chatops"]["session_cache_timeout"],
         )
 
     def unset_session(self):

--- a/nautobot_chatops/tests/test_dispatchers.py
+++ b/nautobot_chatops/tests/test_dispatchers.py
@@ -176,21 +176,26 @@ class TestSlackDispatcher(TestCase):
 
         self.assertIsInstance(response, MagicMock)
 
-    def test_user_session(self):
+    def test_user_session_all(self):
         """Test session caching methods."""
         self.dispatcher.unset_session()
         self.assertEqual(self.dispatcher.get_session(), {})
         self.dispatcher.set_session({"key1": "value1"})
         self.assertEqual(self.dispatcher.get_session(), {"key1": "value1"})
-        self.assertEqual(self.dispatcher.get_session("key1"), "value1")
-        self.dispatcher.set_session("value2", key="key2")
-        self.assertEqual(self.dispatcher.get_session(), {"key1": "value1", "key2": "value2"})
-        self.dispatcher.unset_session("key2")
-        self.assertEqual(self.dispatcher.get_session(), {"key1": "value1"})
         self.dispatcher.unset_session()
         self.assertEqual(self.dispatcher.get_session(), {})
         with self.assertRaises(ValueError):
             self.dispatcher.set_session("value3")
+
+    def test_user_session_key(self):
+        """Test session caching methods per key."""
+        self.dispatcher.unset_session()
+        self.dispatcher.set_session_entry("key1", "value1")
+        self.assertEqual(self.dispatcher.get_session_entry("key1"), "value1")
+        self.dispatcher.unset_session_entry("key1")
+        self.assertEqual(self.dispatcher.get_session_entry("key1"), None)
+        # This should not raise an exception
+        self.dispatcher.unset_session_entry("key1")
 
 
 class TestMSTeamsDispatcher(TestSlackDispatcher):

--- a/nautobot_chatops/tests/test_dispatchers.py
+++ b/nautobot_chatops/tests/test_dispatchers.py
@@ -176,6 +176,15 @@ class TestSlackDispatcher(TestCase):
 
         self.assertIsInstance(response, MagicMock)
 
+    def test_user_session(self):
+        """Test session caching methods."""
+        self.dispatcher.session = {"key1": "value1"}
+        self.assertEqual(self.dispatcher.session, {"key1": "value1"})
+        self.dispatcher.session = {"key2": "value2"}
+        self.assertEqual(self.dispatcher.session, {"key2": "value2"})
+        self.dispatcher.update_session({"key3": "value3"})
+        self.assertEqual(self.dispatcher.session, {"key2": "value2", "key3": "value3"})
+
 
 class TestMSTeamsDispatcher(TestSlackDispatcher):
     """Test the MSTeamsDispatcher class."""

--- a/nautobot_chatops/tests/test_dispatchers.py
+++ b/nautobot_chatops/tests/test_dispatchers.py
@@ -178,12 +178,19 @@ class TestSlackDispatcher(TestCase):
 
     def test_user_session(self):
         """Test session caching methods."""
-        self.dispatcher.session = {"key1": "value1"}
-        self.assertEqual(self.dispatcher.session, {"key1": "value1"})
-        self.dispatcher.session = {"key2": "value2"}
-        self.assertEqual(self.dispatcher.session, {"key2": "value2"})
-        self.dispatcher.update_session({"key3": "value3"})
-        self.assertEqual(self.dispatcher.session, {"key2": "value2", "key3": "value3"})
+        self.dispatcher.unset_session()
+        self.assertEqual(self.dispatcher.get_session(), {})
+        self.dispatcher.set_session({"key1": "value1"})
+        self.assertEqual(self.dispatcher.get_session(), {"key1": "value1"})
+        self.assertEqual(self.dispatcher.get_session("key1"), "value1")
+        self.dispatcher.set_session("value2", key="key2")
+        self.assertEqual(self.dispatcher.get_session(), {"key1": "value1", "key2": "value2"})
+        self.dispatcher.unset_session("key2")
+        self.assertEqual(self.dispatcher.get_session(), {"key1": "value1"})
+        self.dispatcher.unset_session()
+        self.assertEqual(self.dispatcher.get_session(), {})
+        with self.assertRaises(ValueError):
+            self.dispatcher.set_session("value3")
 
 
 class TestMSTeamsDispatcher(TestSlackDispatcher):


### PR DESCRIPTION
Addressing feature #87 

Simply add a `session` data per user in the `dispatcher`, so when working on the commands they can `get`, `set` or `update` the user session data and will simplify some commands.

For instance, if all commands require a `snapshot_id` to run the commands against, it's much simpler that the user defines it with a command such as `set-snapshot` that will `set` or `update` the session info, and the commands will just use this session data.

This data is not persistent, is has a max of 1 day lifetime.