### PR TITLE
Implement maximum msg size check for MS Teams.

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -217,6 +217,7 @@ PLUGINS_CONFIG = {
         "enable_webex": True,
         "microsoft_app_id": os.environ.get("MICROSOFT_APP_ID"),
         "microsoft_app_password": os.environ.get("MICROSOFT_APP_PASSWORD"),
+        "microsoft_max_msg_size": int(os.environ.get("MICROSOFT_MAX_MSG_SIZE", 0)),
         "slack_api_token": os.environ.get("SLACK_API_TOKEN"),
         "slack_signing_secret": os.environ.get("SLACK_SIGNING_SECRET"),
         "slack_slash_command_prefix": os.environ.get("SLACK_SLASH_COMMAND_PREFIX", "/"),

--- a/nautobot_chatops/__init__.py
+++ b/nautobot_chatops/__init__.py
@@ -38,6 +38,7 @@ class NautobotChatOpsConfig(PluginConfig):
         # Microsoft-Teams-specific settings
         "microsoft_app_id": None,
         "microsoft_app_password": None,
+        "microsoft_max_msg_size": None,
         # WebEx-specific settings
         "webex_token": None,
         "webex_signing_secret": None,


### PR DESCRIPTION
Draft proposal of changes needed to implement #106 .

- Add a new setting `microsoft_max_msg_size` which controls maximum allowed message size for MS Teams.
- Set value of `microsoft_max_msg_size` suing `MICROSOFT_MAX_MSG_SIZE` env var. Default to 0.
- Modify MS Teams dispatcher to 
  - perform `json.dumps()` on content before message is sent
  - check the size of resulting string does not exceed `microsoft_max_msg_size` value
  - if the size is too large, return error message to MS Teams chat, and log a warning
  - otherwise continue as normal