### PR TITLE
Fix MS Teams bug with response header when image is not specified.

### DIFF
--- a/nautobot_chatops/dispatchers/adaptive_cards.py
+++ b/nautobot_chatops/dispatchers/adaptive_cards.py
@@ -32,14 +32,18 @@ class AdaptiveCardsDispatcher(Dispatcher):
                             ),
                         ],
                     },
-                    {
-                        "type": "Column",
-                        "width": "80px",  # magic number, trying to make it look similar to Slack's "accessory" icon
-                        "items": [image_element],
-                    },
                 ],
             },
         ]
+
+        if image_element:
+            header[0]["columns"].append(
+                {
+                    "type": "Column",
+                    "width": "80px",  # magic number, trying to make it look similar to Slack's "accessory" icon
+                    "items": [image_element],
+                },
+            )
 
         if args:
             header[0]["columns"][0]["items"].append(


### PR DESCRIPTION
- Modifies `command_response_header` in `adaptive_cards` dispatcher to only include `image_element` column when the `image_element` argument is specified.

Fixes: https://github.com/nautobot/nautobot-plugin-chatops/issues/108