### PR TITLE
Updates CI to include proper on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 ---
 name: "CI"
-on:  # yamllint disable
-  - "push"
-  - "pull_request"
+on: # yamllint disable
+  push:
+    branches:
+      - "develop"
+      - "main"
+  pull_request:
+  release:
+    types:
+      - "published"
 
 jobs:
   black:


### PR DESCRIPTION
It was brought up that 1.5.1 release did not publish to Pypi properly. Looking through the CI setup, it is missing the releases section. This adds releases.