### PR TITLE
Added export button and dependent code to export chatbot command usage as csv

### DIFF
--- a/nautobot_chatops/models.py
+++ b/nautobot_chatops/models.py
@@ -37,6 +37,19 @@ class CommandLog(BaseModel):
     )
     details = models.CharField(max_length=255, default="")
 
+    csv_headers = ["Start Time", "Username", "Command", "Subcommand", "Params", "Status"]
+
+    def to_csv(self):
+        """Indicates model fields to return as csv."""
+        return (
+            self.start_time,
+            self.user_name,
+            self.command,
+            self.subcommand,
+            self.params if self.params else "",
+            self.status,
+        )
+
     @property
     def status_label_class(self):
         """Bootstrap CSS label class for each status value."""

--- a/nautobot_chatops/templates/nautobot/home.html
+++ b/nautobot_chatops/templates/nautobot/home.html
@@ -1,7 +1,5 @@
 {% extends 'base.html' %}
 {% load buttons %}
-{% load static %}
-{% load helpers %}
 
 {% block header %}
     <div class="pull-right noprint">

--- a/nautobot_chatops/templates/nautobot/home.html
+++ b/nautobot_chatops/templates/nautobot/home.html
@@ -1,13 +1,12 @@
 {% extends 'base.html' %}
+{% load buttons %}
+{% load static %}
+{% load helpers %}
 
 {% block header %}
     <div class="pull-right noprint">
-        {% if request.user.is_authenticated %}
-            <!-- <button type="button" class="btn btn-default" data-toggle="modal" data-target="#tableconfig"
-                title="Configure command history table"><i class="mdi mdi-cog"></i> Configure</button> -->
-        {% endif %}
+        {% export_button %}
     </div>
-    {{ block.super }}
     <h1>{% block title %}Nautobot Command Usage Records{% endblock %}</h1>
 {% endblock header %}
 

--- a/nautobot_chatops/tests/test_models.py
+++ b/nautobot_chatops/tests/test_models.py
@@ -1,0 +1,37 @@
+"""Tests for ChatOps models."""
+import datetime
+from unittest.mock import patch
+from django.test import TestCase
+from nautobot.utilities.fields import ColorField
+from nautobot_chatops.choices import CommandStatusChoices
+
+from nautobot_chatops.models import CommandLog
+
+
+class CommandLogTestCase(TestCase):
+    def test_to_csv(self):
+        """Check that `to_csv` returns the correct data from the CommandLog model."""
+        expected_data = (
+            datetime.datetime(2020, 1, 26, 15, 37, 36),
+            "User 1",
+            "nautobot",
+            "get-devices",
+            ["mydevice_1"],
+            "succeeded",
+        )
+        commandlog_a = CommandLog(
+            start_time="2020-01-26T15:37:36",
+            user_name="User 1",
+            command="nautobot",
+            subcommand="get-devices",
+            params=["mydevice_1"],
+            status=CommandStatusChoices.STATUS_SUCCEEDED,
+            runtime="00:00:02",
+            user_id="112233",
+            platform="Slack",
+            platform_color="ff0000",
+            details="This is for testing.",
+        )
+        commandlog_a.validated_save()
+        csv_data = commandlog_a.to_csv()
+        self.assertEqual(expected_data, csv_data)

--- a/nautobot_chatops/tests/test_models.py
+++ b/nautobot_chatops/tests/test_models.py
@@ -1,14 +1,14 @@
 """Tests for ChatOps models."""
 import datetime
-from unittest.mock import patch
 from django.test import TestCase
-from nautobot.utilities.fields import ColorField
 from nautobot_chatops.choices import CommandStatusChoices
 
 from nautobot_chatops.models import CommandLog
 
 
 class CommandLogTestCase(TestCase):
+    """Test case for CommandLog model."""
+
     def test_to_csv(self):
         """Check that `to_csv` returns the correct data from the CommandLog model."""
         expected_data = (

--- a/nautobot_chatops/tests/test_views.py
+++ b/nautobot_chatops/tests/test_views.py
@@ -181,15 +181,15 @@ class TestNautobotHomeView(ViewTestCases):
         """Setup function for test class."""
         commandlog_a = CommandLog(
             start_time="2020-01-26T15:37:36",
-            user_name="User 1",
-            command="nautobot",
-            subcommand="get-devices",
-            params=["mydevice_1"],
+            user_name="User 2",
+            command="meraki",
+            subcommand="get-organizations",
+            params=["myorg_1"],
             status=CommandStatusChoices.STATUS_SUCCEEDED,
-            runtime="00:00:02",
-            user_id="112233",
-            platform="Slack",
-            platform_color="ff0000",
+            runtime="00:00:05",
+            user_id="998877",
+            platform="Teams",
+            platform_color="ffffff",
             details="This is for testing.",
         )
         commandlog_a.validated_save()

--- a/nautobot_chatops/tests/test_views.py
+++ b/nautobot_chatops/tests/test_views.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
-
+from nautobot.utilities.testing import ViewTestCases
 from nautobot_chatops.api.views.slack import (
     verify_signature as slack_verify_signature,
     generate_signature as slack_generate_signature,
@@ -16,8 +16,6 @@ from nautobot_chatops.api.views.webex import (
 from nautobot_chatops.api.views.mattermost import verify_signature as mattermost_verify_signature
 from nautobot_chatops.choices import CommandTokenPlatformChoices
 from nautobot_chatops.models import CommandToken
-from nautobot.utilities.testing import ViewTestCases
-from nautobot.utilities.fields import ColorField
 from nautobot_chatops.choices import CommandStatusChoices
 from nautobot_chatops.models import CommandLog
 
@@ -179,8 +177,8 @@ class TestNautobotHomeView(ViewTestCases):
     """Test the NautobotHomePage View."""
 
     @classmethod
-    def setUpTestData(cls):
-
+    def setUp(cls):  # pylint: disable=invalid-name
+        """Setup function for test class."""
         commandlog_a = CommandLog(
             start_time="2020-01-26T15:37:36",
             user_name="User 1",
@@ -199,6 +197,6 @@ class TestNautobotHomeView(ViewTestCases):
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_queryset_to_csv(self):
         """This view has a custom queryset_to_csv() implementation."""
-        response = self.client.get(f"{self._get_url}?export")
-        self.assertHttpStatus(response, 200)
-        self.assertEqual(response.get("Content-Type"), "text/csv")
+        response = self.client.get(f"{self._get_url}?export")  # pylint: disable=no-member
+        self.assertHttpStatus(response, 200)  # pylint: disable=no-member
+        self.assertEqual(response.get("Content-Type"), "text/csv")  # pylint: disable=no-member

--- a/nautobot_chatops/utils.py
+++ b/nautobot_chatops/utils.py
@@ -55,7 +55,6 @@ try:
             context=context,
         )
 
-
 except ImportError:
     logger.info("INFO: Celery was not found - using Django RQ Worker")
 

--- a/nautobot_chatops/utils.py
+++ b/nautobot_chatops/utils.py
@@ -55,6 +55,7 @@ try:
             context=context,
         )
 
+
 except ImportError:
     logger.info("INFO: Celery was not found - using Django RQ Worker")
 


### PR DESCRIPTION
One of our customers asked about being able to export the data shown in the "command history" table. I noticed a few other of the plugins had an export button (namely Golden Configuration) that exported table data to CSV to download. This is my implementation to do that for the "command history" table. 