### PR TITLE
QOL tweaks / bugfix

### DIFF
--- a/nautobot_chatops/constants.py
+++ b/nautobot_chatops/constants.py
@@ -1,0 +1,14 @@
+COMMAND_LOG_USER_NAME_HELP_TEXT = "Invoking username"
+COMMAND_LOG_USER_ID_HELP_TEXT = "Invoking user ID"
+COMMAND_LOG_PLATFORM_HELP_TEXT = "Chat platform"
+COMMAND_LOG_COMMAND_TEXT = "Command issued"
+COMMAND_LOG_SUBCOMMAND_HELP_TEXT = "Sub-command issued"
+COMMAND_LOG_PARAMS_HELP_TEXT = "user_input_parameters"
+
+ACCESS_GRANT_COMMAND_HELP_TEXT = "Enter <tt>*</tt> to grant access to all commands"
+ACCESS_GRANT_SUBCOMMAND_HELP_TEXT = "Enter <tt>*</tt> to grant access to all subcommands of the given command"
+ACCESS_GRANT_NAME_HELP_TEXT = "Organization name, channel name, or user name"
+ACCESS_GRANT_VALUE_HELP_TEXT = "Corresponding ID value to grant access to.<br>Enter <tt>*</tt> to grant access to all organizations, channels, or users"
+
+COMMAND_TOKEN_COMMENT_HELP_TEXT = "Optional: Enter description of token"
+COMMAND_TOKEN_TOKEN_HELP_TEXT = "Token given by chat platform for signing or command validation"

--- a/nautobot_chatops/constants.py
+++ b/nautobot_chatops/constants.py
@@ -1,3 +1,5 @@
+"""Static variables used in plugin."""
+
 COMMAND_LOG_USER_NAME_HELP_TEXT = "Invoking username"
 COMMAND_LOG_USER_ID_HELP_TEXT = "Invoking user ID"
 COMMAND_LOG_PLATFORM_HELP_TEXT = "Chat platform"
@@ -8,7 +10,10 @@ COMMAND_LOG_PARAMS_HELP_TEXT = "user_input_parameters"
 ACCESS_GRANT_COMMAND_HELP_TEXT = "Enter <tt>*</tt> to grant access to all commands"
 ACCESS_GRANT_SUBCOMMAND_HELP_TEXT = "Enter <tt>*</tt> to grant access to all subcommands of the given command"
 ACCESS_GRANT_NAME_HELP_TEXT = "Organization name, channel name, or user name"
+# pylint: disable=line-too-long
 ACCESS_GRANT_VALUE_HELP_TEXT = "Corresponding ID value to grant access to.<br>Enter <tt>*</tt> to grant access to all organizations, channels, or users"
 
-COMMAND_TOKEN_COMMENT_HELP_TEXT = "Optional: Enter description of token"
-COMMAND_TOKEN_TOKEN_HELP_TEXT = "Token given by chat platform for signing or command validation"
+COMMAND_TOKEN_COMMENT_HELP_TEXT = "Optional: Enter description of token"  # nosec - skips Bandit B105 error
+COMMAND_TOKEN_TOKEN_HELP_TEXT = (
+    "Token given by chat platform for signing or command validation"  # nosec - skips Bandit B105 error
+)

--- a/nautobot_chatops/forms.py
+++ b/nautobot_chatops/forms.py
@@ -6,7 +6,7 @@ from nautobot.utilities.forms import BootstrapMixin
 
 from .models import AccessGrant, CommandToken
 from .choices import AccessGrantTypeChoices, CommandTokenPlatformChoices
-
+from .constants import *
 
 BLANK_CHOICE = (("", "--------"),)
 
@@ -30,6 +30,11 @@ class AccessGrantFilterForm(BootstrapMixin, forms.ModelForm):
 class AccessGrantForm(BootstrapMixin, forms.ModelForm):
     """Form for creating or editing an AccessGrant instance."""
 
+    command = forms.CharField(
+        max_length=64,
+        help_text=ACCESS_GRANT_COMMAND_HELP_TEXT,
+        widget=forms.TextInput(attrs={"autofocus": True}),
+    )
     grant_type = forms.ChoiceField(choices=BLANK_CHOICE + AccessGrantTypeChoices.CHOICES)
 
     class Meta:
@@ -57,6 +62,11 @@ class CommandTokenFilterForm(BootstrapMixin, forms.ModelForm):
 class CommandTokenForm(BootstrapMixin, forms.ModelForm):
     """Form for creating or editing an CommandToken instance."""
 
+    token = forms.CharField(
+        max_length=255,
+        help_text=COMMAND_TOKEN_TOKEN_HELP_TEXT,
+        widget=forms.TextInput(attrs={"autofocus": True}),
+    )
     platform = forms.ChoiceField(choices=CommandTokenPlatformChoices.CHOICES, required=True)
 
     class Meta:

--- a/nautobot_chatops/forms.py
+++ b/nautobot_chatops/forms.py
@@ -6,7 +6,7 @@ from nautobot.utilities.forms import BootstrapMixin
 
 from .models import AccessGrant, CommandToken
 from .choices import AccessGrantTypeChoices, CommandTokenPlatformChoices
-from .constants import *
+from .constants import ACCESS_GRANT_COMMAND_HELP_TEXT, COMMAND_TOKEN_TOKEN_HELP_TEXT
 
 BLANK_CHOICE = (("", "--------"),)
 

--- a/nautobot_chatops/models.py
+++ b/nautobot_chatops/models.py
@@ -9,7 +9,20 @@ from nautobot.core.models import BaseModel
 
 from .choices import AccessGrantTypeChoices, CommandStatusChoices, CommandTokenPlatformChoices
 
-from .constants import *
+from .constants import (
+    COMMAND_LOG_USER_NAME_HELP_TEXT,
+    COMMAND_LOG_USER_ID_HELP_TEXT,
+    COMMAND_LOG_PLATFORM_HELP_TEXT,
+    COMMAND_LOG_COMMAND_TEXT,
+    COMMAND_LOG_SUBCOMMAND_HELP_TEXT,
+    COMMAND_LOG_PARAMS_HELP_TEXT,
+    ACCESS_GRANT_COMMAND_HELP_TEXT,
+    ACCESS_GRANT_SUBCOMMAND_HELP_TEXT,
+    ACCESS_GRANT_NAME_HELP_TEXT,
+    ACCESS_GRANT_VALUE_HELP_TEXT,
+    COMMAND_TOKEN_COMMENT_HELP_TEXT,
+    COMMAND_TOKEN_TOKEN_HELP_TEXT,
+)
 
 
 class CommandLog(BaseModel):

--- a/nautobot_chatops/models.py
+++ b/nautobot_chatops/models.py
@@ -9,6 +9,8 @@ from nautobot.core.models import BaseModel
 
 from .choices import AccessGrantTypeChoices, CommandStatusChoices, CommandTokenPlatformChoices
 
+from .constants import *
+
 
 class CommandLog(BaseModel):
     """Record of a single fully-executed Nautobot command.
@@ -20,15 +22,15 @@ class CommandLog(BaseModel):
     start_time = models.DateTimeField(null=True)
     runtime = models.DurationField(null=True)
 
-    user_name = models.CharField(max_length=255, help_text="Invoking username")
-    user_id = models.CharField(max_length=255, help_text="Invoking user ID")
-    platform = models.CharField(max_length=64, help_text="Chat platform")
+    user_name = models.CharField(max_length=255, help_text=COMMAND_LOG_USER_NAME_HELP_TEXT)
+    user_id = models.CharField(max_length=255, help_text=COMMAND_LOG_USER_ID_HELP_TEXT)
+    platform = models.CharField(max_length=64, help_text=COMMAND_LOG_PLATFORM_HELP_TEXT)
     platform_color = ColorField()
 
-    command = models.CharField(max_length=64, help_text="Command issued")
-    subcommand = models.CharField(max_length=64, help_text="Sub-command issued")
+    command = models.CharField(max_length=64, help_text=COMMAND_LOG_COMMAND_TEXT)
+    subcommand = models.CharField(max_length=64, help_text=COMMAND_LOG_SUBCOMMAND_HELP_TEXT)
 
-    params = models.JSONField(default=list, help_text="user_input_parameters")
+    params = models.JSONField(default=list, help_text=COMMAND_LOG_PARAMS_HELP_TEXT)
 
     status = models.CharField(
         max_length=32,
@@ -63,21 +65,18 @@ class CommandLog(BaseModel):
 class AccessGrant(BaseModel, ChangeLoggedModel):
     """Record of a single form of access granted to the chatbot."""
 
-    command = models.CharField(max_length=64, help_text="Enter <tt>*</tt> to grant access to all commands")
+    command = models.CharField(max_length=64, help_text=ACCESS_GRANT_COMMAND_HELP_TEXT)
     subcommand = models.CharField(
         max_length=64,
-        help_text="Enter <tt>*</tt> to grant access to all subcommands of the given command",
+        help_text=ACCESS_GRANT_SUBCOMMAND_HELP_TEXT,
     )
 
     grant_type = models.CharField(max_length=32, choices=AccessGrantTypeChoices)
 
-    name = models.CharField(max_length=255, help_text="Organization name, channel name, or user name")
+    name = models.CharField(max_length=255, help_text=ACCESS_GRANT_NAME_HELP_TEXT)
     value = models.CharField(
         max_length=255,
-        help_text=(
-            "Corresponding ID value to grant access to.<br>"
-            "Enter <tt>*</tt> to grant access to all organizations, channels, or users"
-        ),
+        help_text=ACCESS_GRANT_VALUE_HELP_TEXT,
     )
 
     def clean(self):
@@ -99,9 +98,9 @@ class AccessGrant(BaseModel, ChangeLoggedModel):
 class CommandToken(BaseModel, ChangeLoggedModel):
     """Record of a Token granted for the chat platform and chat command."""
 
-    comment = models.CharField(max_length=255, help_text="Optional: Enter description of token", blank=True, default="")
+    comment = models.CharField(max_length=255, help_text=COMMAND_TOKEN_COMMENT_HELP_TEXT, blank=True, default="")
     platform = models.CharField(max_length=32, choices=CommandTokenPlatformChoices)
-    token = models.CharField(max_length=255, help_text="Token given by chat platform for signing or command validation")
+    token = models.CharField(max_length=255, help_text=COMMAND_TOKEN_TOKEN_HELP_TEXT)
 
     def __str__(self):
         """String representation of a CommandToken."""

--- a/nautobot_chatops/templates/nautobot/access_grant_edit.html
+++ b/nautobot_chatops/templates/nautobot/access_grant_edit.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load form_helpers %}
 
-<h1>{% block title %}{% if obj.command %}Editing{% else %}Add a new{% endif %} Nautobot Access Grant{% endblock %}</h1>
+<h1>{% block title %}{% if obj.present_in_database %}Editing{% else %}Add a new{% endif %} Nautobot Access Grant{% endblock %}</h1>
 
 {% block form %}
 <div class="panel panel-default">

--- a/nautobot_chatops/templates/nautobot/access_grant_edit.html
+++ b/nautobot_chatops/templates/nautobot/access_grant_edit.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load form_helpers %}
 
-<h1>{% block title %}{% if obj.pk %}Editing{% else %}Add a new{% endif %} Nautobot Access Grant{% endblock %}</h1>
+<h1>{% block title %}{% if obj.command %}Editing{% else %}Add a new{% endif %} Nautobot Access Grant{% endblock %}</h1>
 
 {% block form %}
 <div class="panel panel-default">

--- a/nautobot_chatops/templates/nautobot/command_token_edit.html
+++ b/nautobot_chatops/templates/nautobot/command_token_edit.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load form_helpers %}
 
-<h1>{% block title %}{% if obj.token %}Editing{% else %}Add a new{% endif %} Nautobot Command Token{% endblock %}</h1>
+<h1>{% block title %}{% if obj.present_in_database %}Editing{% else %}Add a new{% endif %} Nautobot Command Token{% endblock %}</h1>
 
 {% block form %}
 <div class="panel panel-default">

--- a/nautobot_chatops/templates/nautobot/command_token_edit.html
+++ b/nautobot_chatops/templates/nautobot/command_token_edit.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load form_helpers %}
 
-<h1>{% block title %}{% if obj.pk %}Editing{% else %}Add a new{% endif %} Nautobot Command Token{% endblock %}</h1>
+<h1>{% block title %}{% if obj.token %}Editing{% else %}Add a new{% endif %} Nautobot Command Token{% endblock %}</h1>
 
 {% block form %}
 <div class="panel panel-default">


### PR DESCRIPTION
I've added two minor changes into this PR:

The header for the page for adding a new access grant, as well as a new command token, is supposed to change between "Adding" and "Editing".  However this is always showing as "Editing".  The reason is the `obj.pk` is generated when the page is loaded, so it always appear to exist.

The second item is a quality of life change, but it makes autofocuses the primary text field when opening the "Access Grant" or "Command Token" form.  When doing this, I moved the help text strings to a separate, static file to prevent duplicating their values across models.py and forms.py.