### PR TITLE
Fixes Private Message Error

### DIFF
--- a/nautobot_chatops/dispatchers/base.py
+++ b/nautobot_chatops/dispatchers/base.py
@@ -7,7 +7,7 @@ from django.conf import settings
 
 from texttable import Texttable
 
-logger = logging.getLogger("rq.worker")
+logger = logging.getLogger(__name__)
 
 
 class Dispatcher:

--- a/nautobot_chatops/dispatchers/mattermost.py
+++ b/nautobot_chatops/dispatchers/mattermost.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from nautobot_chatops.metrics import backend_action_sum
 from .base import Dispatcher
 
-logger = logging.getLogger("rq.worker")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=abstract-method,line-too-long,raise-missing-from
 

--- a/nautobot_chatops/dispatchers/ms_teams.py
+++ b/nautobot_chatops/dispatchers/ms_teams.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from nautobot_chatops.metrics import backend_action_sum
 from .adaptive_cards import AdaptiveCardsDispatcher
 
-logger = logging.getLogger("rq.worker")
+logger = logging.getLogger(__name__)
 
 # Create a metric to track time spent and requests made.
 BACKEND_ACTION_LOOKUP = backend_action_sum.labels("msteams", "platform_lookup")

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -232,7 +232,7 @@ class SlackDispatcher(Dispatcher):
                 message_list = self.split_message(text, SLACK_MAX_MESSAGE_LENGTH)
                 for msg in message_list:
                     # Send the blocks as a list, this needs to be the case for Slack to send appropriately.
-                    self.send_blocks([self.markdown_block(msg)], ephemeral=ephemeral)
+                    self.send_blocks([self.markdown_block(f"```\n{msg}\n```")], ephemeral=ephemeral)
             else:
                 self.slack_client.files_upload(channels=channels, content=text, title=title)
         except SlackClientError as slack_error:

--- a/nautobot_chatops/dispatchers/slack.py
+++ b/nautobot_chatops/dispatchers/slack.py
@@ -13,7 +13,7 @@ from slack_sdk.errors import SlackApiError, SlackClientError
 from nautobot_chatops.metrics import backend_action_sum
 from .base import Dispatcher
 
-logger = logging.getLogger("rq.worker")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=abstract-method
 
@@ -231,7 +231,8 @@ class SlackDispatcher(Dispatcher):
             if ephemeral:
                 message_list = self.split_message(text, SLACK_MAX_MESSAGE_LENGTH)
                 for msg in message_list:
-                    self.send_blocks(self.markdown_block(f"```\n{msg}\n```"), ephemeral=ephemeral)
+                    # Send the blocks as a list, this needs to be the case for Slack to send appropriately.
+                    self.send_blocks([self.markdown_block(msg)], ephemeral=ephemeral)
             else:
                 self.slack_client.files_upload(channels=channels, content=text, title=title)
         except SlackClientError as slack_error:

--- a/nautobot_chatops/dispatchers/webex.py
+++ b/nautobot_chatops/dispatchers/webex.py
@@ -10,7 +10,7 @@ from texttable import Texttable
 from nautobot_chatops.metrics import backend_action_sum
 from .adaptive_cards import AdaptiveCardsDispatcher
 
-logger = logging.getLogger("rq.worker")
+logger = logging.getLogger(__name__)
 
 # Create a metric to track time spent and requests made.
 BACKEND_ACTION_LOOKUP = backend_action_sum.labels("webex", "platform_lookup")

--- a/nautobot_chatops/workers/__init__.py
+++ b/nautobot_chatops/workers/__init__.py
@@ -18,7 +18,7 @@ from nautobot_chatops.models import CommandLog
 from nautobot_chatops.utils import create_command_log
 from nautobot_chatops.metrics import request_command_cntr, command_histogram
 
-logger = logging.getLogger("rq.worker")
+logger = logging.getLogger(__name__)
 
 
 _registry_initialized = False  # pylint: disable=invalid-name


### PR DESCRIPTION
The original implementation missed sending one section as blocks. This PR fixes that reported in #127.

During attempting to resolve this, I also found that we had the logger set to the rq.worker only. This has been updated to solve the issue identified in 127.