### PR TITLE
Add suggested custom CSS for mkdocstrings

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -61,3 +61,32 @@ img.copyright-logo {
         background-color: #212121;
     }
 }
+
+/* Customization for mkdocstrings */
+/* Indentation. */
+div.doc-contents:not(.first) {
+    padding-left: 25px;
+    border-left: .2rem solid var(--md-typeset-table-color);
+}
+
+/* Mark external links as such. */
+a.autorefs-external::after {
+    /* https://primer.style/octicons/arrow-up-right-24 */
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="rgb(0, 0, 0)" d="M18.25 15.5a.75.75 0 00.75-.75v-9a.75.75 0 00-.75-.75h-9a.75.75 0 000 1.5h7.19L6.22 16.72a.75.75 0 101.06 1.06L17.5 7.56v7.19c0 .414.336.75.75.75z"></path></svg>');
+    content: ' ';
+
+    display: inline-block;
+    position: relative;
+    top: 0.1em;
+    margin-left: 0.2em;
+    margin-right: 0.1em;
+
+    height: 1em;
+    width: 1em;
+    border-radius: 100%;
+    background-color: var(--md-typeset-a-color);
+}
+
+a.autorefs-external:hover::after {
+    background-color: var(--md-accent-fg-color);
+}

--- a/docs/dev/dev_contributing.md
+++ b/docs/dev/dev_contributing.md
@@ -5,6 +5,7 @@ Pull requests are welcomed and automatically built and tested against multiple v
 The project is packaged with a light development environment based on `docker-compose` to help with the local development of the project and to run the tests within Github Actions.
 
 The project is following Network to Code software development guidelines and is leveraging:
+
 - Black, Pylint, Bandit and pydocstyle for Python linting and formatting.
 - Django unit test to ensure the plugin is working properly.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,6 @@ plugins:
           paths: ["."]
           options:
             show_root_heading: true
-            show_category_heading: false
 
 watch:
   - "README.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,7 @@ plugins:
           paths: ["."]
           options:
             show_root_heading: true
-            show_category_heading: true
+            show_category_heading: false
 
 watch:
   - "README.md"


### PR DESCRIPTION
Makes it so that code hierarchy is properly displayed in the `mkdocstrings` generated code reference. Also disabled the `show_category_heading` option to reduce the crazy amount of nested headings.

![image](https://user-images.githubusercontent.com/9288571/193649229-08be0d2d-5af5-41f8-aba6-3dee95ac8d99.png)

Bonus: add missing newline before markdown list so it renders properly.