### PR TITLE
Add Compatibility Matrix

### DIFF
--- a/docs/admin/compatibility_matrix.md
+++ b/docs/admin/compatibility_matrix.md
@@ -1,0 +1,20 @@
+# Compatibility Matrix
+
+Changes to the support of upstream Nautobot releases will be announced 1 minor or major version ahead.
+
+The **deprecation policy** will be announced within the [release notes](release_notes/index.md), and updated in the table below. There will be a `stable-<major>.<minor>` branch that will be minimally maintained. Any security enhancements or major bugs in that branch will be supported for a limited time.
+
+While that last supported version will not be strictly enforced via the `max_version` setting, any issues with an updated Nautobot supported version in a minor release will require raising a bug and fixing it in Nautobot core, with no fixes expected in this plugin. This allows the Chatops plugin the ability to quickly take advantage of the latest features in Nautobot.
+
+| Chatops Version | Nautobot First Support Version | Nautobot Last Support Version |
+| --------------- | ------------------------------ | ----------------------------- |
+| 1.0.X           | 1.0.0                          | 1.2.99 [Official]             |
+| 1.1.X           | 1.0.0                          | 1.2.99 [Official]             |
+| 1.2.X           | 1.0.0                          | 1.2.99 [Official]             |
+| 1.3.X           | 1.0.0                          | 1.2.99 [Official]             |
+| 1.4.X           | 1.0.0                          | 1.2.99 [Official]             |
+| 1.5.X           | 1.0.0                          | 1.2.99 [Official]             |
+| 1.6.X           | 1.0.0                          | 1.2.99 [Official]             |
+| 1.7.X           | 1.0.0                          | 1.2.99 [Official]             |
+| 1.8.X           | 1.1.0                          | 1.4.99 [Official]             |
+| 1.9.X           | 1.2.0                          | 1.5.99 [Official]             |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
           - "admin/install/microsoft_teams_setup.md"
       - Upgrade: "admin/admin_upgrade.md"
       - Uninstall: "admin/admin_uninstall.md"
+      - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
           - v1.9: "admin/release_notes/version_1.9.md"


### PR DESCRIPTION
This PR adds a Compatibility Matrix to show which versions of the Chatops plugin are compatible with the different Nautobot versions.