### PR TITLE
Changed extends base.html to extends generic/object_list.html for list templates

### DIFF
--- a/nautobot_chatops/templates/nautobot/access_grant_list.html
+++ b/nautobot_chatops/templates/nautobot/access_grant_list.html
@@ -1,6 +1,4 @@
-{% extends 'base.html' %}
-{% load buttons %}
-{% load helpers %}
+{% extends 'generic/object_list.html' %}
 
 {% block content %}
 <div class="pull-right noprint">

--- a/nautobot_chatops/templates/nautobot/command_token_list.html
+++ b/nautobot_chatops/templates/nautobot/command_token_list.html
@@ -1,6 +1,4 @@
-{% extends 'base.html' %}
-{% load buttons %}
-{% load helpers %}
+{% extends 'generic/object_list.html' %}
 
 {% block content %}
 <div class="pull-right noprint">


### PR DESCRIPTION
# Closes: #174 

## What's Changed
Changed `extends 'base.html'` to `extends 'generic/object_list.html'` in list templates and removed unneeded `load`s from these templates.
