### PR TITLE
Move Changelog Fragment documentation - Release 2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        nautobot-version: ["1.5.4", "latest"]
+        nautobot-version: ["1.5.4", "stable"]
     runs-on: "ubuntu-20.04"
     env:
       INVOKE_NAUTOBOT_CHATOPS_PYTHON_VER: "${{ matrix.python-version }}"

--- a/changes/228.changed
+++ b/changes/228.changed
@@ -1,1 +1,0 @@
-Move Contributing Changelog Fragments higher in documentation

--- a/changes/228.changed
+++ b/changes/228.changed
@@ -1,0 +1,1 @@
+Move Contributing Changelog Fragments higher in documentation

--- a/docs/admin/release_notes/version_2.0.md
+++ b/docs/admin/release_notes/version_2.0.md
@@ -2,6 +2,13 @@
 # v2.0 Release Notes
 
 <!-- towncrier release notes start -->
+## [v2.0.1 (2023-08-03)](https://github.com/nautobot/nautobot-plugin-chatops/releases/tag/v2.0.1)
+
+### Changed
+
+- [#228](https://github.com/nautobot/nautobot-plugin-chatops/issues/228) - Move Contributing Changelog Fragments higher in documentation
+
+
 ## [v2.0.0 (2023-08-02)](https://github.com/nautobot/nautobot-plugin-chatops/releases/tag/v2.0.0)
 
 ### Added

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -172,11 +172,11 @@ You shouldn't need to make any changes to the `workers` module in this scenario.
 
 - All code submissions should meet the following criteria (CI will enforce
 these checks):
-  - Python syntax is valid
-  - All unit tests pass successfully
-  - PEP 8 compliance is enforced, with the exception that lines may be
+    - Python syntax is valid
+    - All unit tests pass successfully
+    - PEP 8 compliance is enforced, with the exception that lines may be
     greater than 80 characters in length
-  - At least one [changelog fragment](#creating-changelog-fragments) has
+    - At least one [changelog fragment](#creating-changelog-fragments) has
     been included in the feature branch
 
 ## Branching Policy
@@ -197,19 +197,19 @@ Nautobot ChatOps currently has no intended scheduled release schedule, and will 
 When a new release of any kind (e.g. from `develop` to `main`, or a release of a `stable-<major>.<minor>`) is created the following should happen.
 
 - A release PR is created:
-  - Add and/or update to the changelog in `docs/admin/release_notes/version_<major>.<minor>.md` file to reflect the changes.
-  - Update the mkdocs.yml file to include updates when adding a new release_notes version file.
-  - Change the version from `<major>.<minor>.<patch>-beta` to `<major>.<minor>.<patch>` in `pyproject.toml`.
-  - Set the PR to the proper branch, e.g. either `main` or `stable-<major>.<minor>`.
+    - Add and/or update to the changelog in `docs/admin/release_notes/version_<major>.<minor>.md` file to reflect the changes.
+    - Update the mkdocs.yml file to include updates when adding a new release_notes version file.
+    - Change the version from `<major>.<minor>.<patch>-beta` to `<major>.<minor>.<patch>` in `pyproject.toml`.
+    - Set the PR to the proper branch, e.g. either `main` or `stable-<major>.<minor>`.
 - Ensure the tests for the PR pass.
 - Merge the PR.
 - Create a new tag:
-  - The tag should be in the form of `v<major>.<minor>.<patch>`.
-  - The title should be in the form of `v<major>.<minor>.<patch>`.
-  - The description should be the changes that were added to the `version_<major>.<minor>.md` document.
+    - The tag should be in the form of `v<major>.<minor>.<patch>`.
+    - The title should be in the form of `v<major>.<minor>.<patch>`.
+    - The description should be the changes that were added to the `version_<major>.<minor>.md` document.
 - If merged into `main`, then push from `main` to `develop`, in order to retain the merge commit created when the PR was merged.
 - If there is a new `<major>.<minor>`, create a `stable-<major>.<minor>` for the **previous** version, so that security updates to old versions may be applied more easily.
 - A post release PR is created:
-  - Change the version from `<major>.<minor>.<patch>` to `<major>.<minor>.<patch + 1>-beta` in `pyproject.toml`.
-  - Set the PR to the proper branch, e.g. either `develop` or `stable-<major>.<minor>`.
-  - Once tests pass, merge.
+    - Change the version from `<major>.<minor>.<patch>` to `<major>.<minor>.<patch + 1>-beta` in `pyproject.toml`.
+    - Set the PR to the proper branch, e.g. either `develop` or `stable-<major>.<minor>`.
+    - Once tests pass, merge.

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -11,6 +11,35 @@ The project is following Network to Code software development guidelines and is 
 Documentation is built using [mkdocs](https://www.mkdocs.org/).
 The [Docker based development environment](dev_environment.md#docker-development-environment) automatically starts a container hosting a live version of the documentation website on [http://localhost:8001](http://localhost:8001) that auto-refreshes when you make any changes to your local files.
 
+## Creating Changelog Fragments
+
+All pull requests to `next` or `develop` must include a changelog fragment file in the `./changes` directory. To create a fragment, use your GitHub issue number and fragment type as the filename. For example, `2362.added`. Valid fragment types are `added`, `changed`, `deprecated`, `fixed`, `removed`, and `security`. The change summary is added to the file in plain text. Change summaries should be complete sentences, starting with a capital letter and ending with a period, and be in past tense. Each line of the change fragment will generate a single change entry in the release notes. Use multiple lines in the same file if your change needs to generate multiple release notes in the same category. If the change needs to create multiple entries in separate categories, create multiple files.
+
+!!! example
+
+    **Wrong**
+    ```plaintext title="changes/1234.fixed"
+    fix critical bug in documentation
+    ```
+
+    **Right**
+    ```plaintext title="changes/1234.fixed"
+    Fixed critical bug in documentation.
+    ```
+
+!!! example "Multiple Entry Example"
+
+    This will generate 2 entries in the `fixed` category and one entry in the `changed` category.
+
+    ```plaintext title="changes/1234.fixed"
+    Fixed critical bug in documentation.
+    Fixed release notes generation.
+    ```
+
+    ```plaintext title="changes/1234.changed"
+    Changed release notes generation.
+    ```
+
 ## Adding a new top-level command
 
 First, you should be familiar with the design goals and constraints involved in Nautobot (`design.md`).
@@ -150,43 +179,14 @@ these checks):
   - At least one [changelog fragment](#creating-changelog-fragments) has
     been included in the feature branch
 
-### Creating Changelog Fragments
-
-All pull requests to `next` or `develop` must include a changelog fragment file in the `./changes` directory. To create a fragment, use your GitHub issue number and fragment type as the filename. For example, `2362.added`. Valid fragment types are `added`, `changed`, `deprecated`, `fixed`, `removed`, and `security`. The change summary is added to the file in plain text. Change summaries should be complete sentences, starting with a capital letter and ending with a period, and be in past tense. Each line of the change fragment will generate a single change entry in the release notes. Use multiple lines in the same file if your change needs to generate multiple release notes in the same category. If the change needs to create multiple entries in separate categories, create multiple files.
-
-!!! example
-
-    **Wrong**
-    ```plaintext title="changes/1234.fixed"
-    fix critical bug in documentation
-    ```
-
-    **Right**
-    ```plaintext title="changes/1234.fixed"
-    Fixed critical bug in documentation.
-    ```
-
-!!! example "Multiple Entry Example"
-
-    This will generate 2 entries in the `fixed` category and one entry in the `changed` category.
-
-    ```plaintext title="changes/1234.fixed"
-    Fixed critical bug in documentation.
-    Fixed release notes generation.
-    ```
-
-    ```plaintext title="changes/1234.changed"
-    Changed release notes generation.
-    ```
-
 ## Branching Policy
 
 The branching policy includes the following tenets:
 
-* The `develop` branch is the primary branch to develop off of.
-* PRs intended to add new features should be sourced from the `develop` branch.
-* PRs intended to address bug fixes and security patches should be sourced from the `develop` branch.
-* PRs intended to add new features that break backward compatibility should be discussed before a PR is created.
+- The `develop` branch is the primary branch to develop off of.
+- PRs intended to add new features should be sourced from the `develop` branch.
+- PRs intended to address bug fixes and security patches should be sourced from the `develop` branch.
+- PRs intended to add new features that break backward compatibility should be discussed before a PR is created.
 
 Nautobot ChatOps app will observe semantic versioning, as of 1.0. This may result in a quick turn around in minor versions to keep pace with an ever-growing feature set.
 
@@ -197,19 +197,19 @@ Nautobot ChatOps currently has no intended scheduled release schedule, and will 
 When a new release of any kind (e.g. from `develop` to `main`, or a release of a `stable-<major>.<minor>`) is created the following should happen.
 
 - A release PR is created:
-    - Add and/or update to the changelog in `docs/admin/release_notes/version_<major>.<minor>.md` file to reflect the changes.
-    - Update the mkdocs.yml file to include updates when adding a new release_notes version file.
-    - Change the version from `<major>.<minor>.<patch>-beta` to `<major>.<minor>.<patch>` in `pyproject.toml`.
-    - Set the PR to the proper branch, e.g. either `main` or `stable-<major>.<minor>`.
+  - Add and/or update to the changelog in `docs/admin/release_notes/version_<major>.<minor>.md` file to reflect the changes.
+  - Update the mkdocs.yml file to include updates when adding a new release_notes version file.
+  - Change the version from `<major>.<minor>.<patch>-beta` to `<major>.<minor>.<patch>` in `pyproject.toml`.
+  - Set the PR to the proper branch, e.g. either `main` or `stable-<major>.<minor>`.
 - Ensure the tests for the PR pass.
 - Merge the PR.
 - Create a new tag:
-    - The tag should be in the form of `v<major>.<minor>.<patch>`.
-    - The title should be in the form of `v<major>.<minor>.<patch>`.
-    - The description should be the changes that were added to the `version_<major>.<minor>.md` document.
+  - The tag should be in the form of `v<major>.<minor>.<patch>`.
+  - The title should be in the form of `v<major>.<minor>.<patch>`.
+  - The description should be the changes that were added to the `version_<major>.<minor>.md` document.
 - If merged into `main`, then push from `main` to `develop`, in order to retain the merge commit created when the PR was merged.
 - If there is a new `<major>.<minor>`, create a `stable-<major>.<minor>` for the **previous** version, so that security updates to old versions may be applied more easily.
 - A post release PR is created:
-    - Change the version from `<major>.<minor>.<patch>` to `<major>.<minor>.<patch + 1>-beta` in `pyproject.toml`.
-    - Set the PR to the proper branch, e.g. either `develop` or `stable-<major>.<minor>`.
-    - Once tests pass, merge.
+  - Change the version from `<major>.<minor>.<patch>` to `<major>.<minor>.<patch + 1>-beta` in `pyproject.toml`.
+  - Set the PR to the proper branch, e.g. either `develop` or `stable-<major>.<minor>`.
+  - Once tests pass, merge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-chatops"
-version = "2.0.0"
+version = "2.0.1"
 description = "A plugin providing chatbot capabilities for Nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
Also switches from latest to stable for nautobot containers.

<!--
    Thank you for your interest in contributing to Nautobot ChatOps! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #228 

## What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Moved the Changelog Fragment documentation higher in the doc, and switched from testing against `latest` to `stable` in the CI pipeline.
