### PR TITLE
fix: Use App without extras installed

### DIFF
--- a/nautobot_chatops/integrations/grafana/helpers.py
+++ b/nautobot_chatops/integrations/grafana/helpers.py
@@ -2,13 +2,6 @@
 from typing import List
 from termcolor import colored
 
-from nautobot.dcim import models as dcim_models
-from nautobot.ipam import models as ipam_models
-from nautobot.extras import models as extra_models
-from nautobot.tenancy import models as tenancy_models
-from nautobot.virtualization import models as virtualization_models
-from nautobot.circuits import models as circuit_models
-
 from schema_enforcer import config
 from schema_enforcer.schemas.manager import SchemaManager
 from schema_enforcer.instances.file import InstanceFileManager
@@ -22,18 +15,6 @@ SPECIAL_CHAR = {
     "<": "less-than",
     ">": "greater-than",
 }
-
-# Valid models to be used in Panel Variables as query options. If a model doesn't exist in
-# this list, you cannot set or use the `query` field in a panel variable.
-VALID_MODELS = (
-    dcim_models,
-    ipam_models,
-    extra_models,
-    tenancy_models,
-    virtualization_models,
-    circuit_models,
-)
-
 
 def format_command(command: str) -> str:
     """_format_command_name will format the panel titles into a valid slash command.

--- a/nautobot_chatops/integrations/grafana/models.py
+++ b/nautobot_chatops/integrations/grafana/models.py
@@ -3,9 +3,26 @@ from django.db import models
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.translation import gettext_lazy as _
-from nautobot.extras.utils import extras_features
+from nautobot.circuits import models as circuit_models
 from nautobot.core.models.generics import PrimaryModel, OrganizationalModel
-from nautobot_chatops.integrations.grafana.helpers import VALID_MODELS
+from nautobot.dcim import models as dcim_models
+from nautobot.extras import models as extra_models
+from nautobot.extras.utils import extras_features
+from nautobot.ipam import models as ipam_models
+from nautobot.tenancy import models as tenancy_models
+from nautobot.virtualization import models as virtualization_models
+
+
+# Valid models to be used in Panel Variables as query options. If a model doesn't exist in
+# this list, you cannot set or use the `query` field in a panel variable.
+VALID_MODELS = (
+    dcim_models,
+    ipam_models,
+    extra_models,
+    tenancy_models,
+    virtualization_models,
+    circuit_models,
+)
 
 
 @extras_features(

--- a/nautobot_chatops/integrations/grafana/worker.py
+++ b/nautobot_chatops/integrations/grafana/worker.py
@@ -12,8 +12,7 @@ from pydantic.error_wrappers import ValidationError  # pylint: disable=no-name-i
 from nautobot.utilities.querysets import RestrictedQuerySet
 from nautobot_chatops.dispatchers import Dispatcher
 from nautobot_chatops.workers import handle_subcommands, add_subcommand
-from nautobot_chatops.integrations.grafana.models import Panel, PanelVariable
-from nautobot_chatops.integrations.grafana.helpers import VALID_MODELS
+from nautobot_chatops.integrations.grafana.models import Panel, PanelVariable, VALID_MODELS
 from nautobot_chatops.integrations.grafana.grafana import (
     SLASH_COMMAND,
     LOGGER,

--- a/nautobot_chatops/urls.py
+++ b/nautobot_chatops/urls.py
@@ -1,4 +1,5 @@
 """Django urlpatterns declaration for nautobot_chatops plugin."""
+import logging
 
 from django.urls import path
 
@@ -17,7 +18,14 @@ from nautobot_chatops.views import (
     AccessGrantBulkDeleteView,
 )
 
-from nautobot_chatops.integrations.grafana.urls import urlpatterns as grafana_urlpatterns
+try:
+    from nautobot_chatops.integrations.grafana.urls import urlpatterns as grafana_urlpatterns
+# pylint: disable-next=broad-except
+except Exception:
+    grafana_urlpatterns = []
+    logger = logging.getLogger(__name__)
+    logger.warning("Grafana ChatOps integration is not available.", exc_info=True)
+    
 
 urlpatterns = [
     path("", NautobotHomeView.as_view(), name="home"),


### PR DESCRIPTION
# Closes NaN

Currently, when installing without extras, ChatOps App fails to initialize. This PR fixes that to allow https://github.com/nautobot/nautobot-plugin-ssot/pull/137

## What's changed:

- Moved Grafana VALID_MODELS to grafana models to avoid unnecessary import.
- Encapsulate importing grafana urls to `try ... except` block